### PR TITLE
Add sarcastic personality layer and engagement systems

### DIFF
--- a/bot/src/bot responses/memes.json
+++ b/bot/src/bot responses/memes.json
@@ -1,0 +1,9 @@
+{
+  "Memes": [
+    "https://i.imgur.com/0y8F8qM.png",
+    "https://i.imgur.com/aw4kxdh.jpg",
+    "https://i.imgur.com/ufxIZhS.jpeg",
+    "https://i.imgur.com/FcwZ1cX.png",
+    "https://i.imgur.com/yAXuJfF.jpeg"
+  ]
+}

--- a/bot/src/database/models.js
+++ b/bot/src/database/models.js
@@ -1,5 +1,30 @@
 import mongoose from 'mongoose';
 
+const achievementSchema = new mongoose.Schema({
+  key: { type: String, index: true },
+  label: String,
+  description: String,
+  unlockedAt: { type: Date, default: Date.now },
+  meta: mongoose.Schema.Types.Mixed
+}, { _id: false });
+
+const communityStatsSchema = new mongoose.Schema({
+  gmCount: { type: Number, default: 0 },
+  gnCount: { type: Number, default: 0 },
+  gmStreak: { type: Number, default: 0 },
+  gnStreak: { type: Number, default: 0 },
+  longestGmStreak: { type: Number, default: 0 },
+  longestGnStreak: { type: Number, default: 0 },
+  lastGMAt: Date,
+  lastGNAt: Date,
+  memesPosted: { type: Number, default: 0 },
+  lastMemeAt: Date,
+  lastInteractionAt: Date,
+  lastResurrectionAt: Date,
+  resurrectionCount: { type: Number, default: 0 },
+  chatterOptOut: { type: Boolean, default: false }
+}, { _id: false });
+
 const userSchema = new mongoose.Schema({
   discordId: { type: String, unique: true, index: true, sparse: true }, // Make sparse for web-only users
   username: String,
@@ -8,6 +33,11 @@ const userSchema = new mongoose.Schema({
   ethAddress: { type: String, index: true },
   solAddress: { type: String, index: true },
   badges: [{ type: String }],
+  achievements: { type: [achievementSchema], default: [] },
+  community: { type: communityStatsSchema, default: () => ({}) },
+  shadowbanned: { type: Boolean, default: false, index: true },
+  autoPostOptOut: { type: Boolean, default: false },
+  lastActive: { type: Date, default: Date.now, index: true },
   email: { type: String, index: true, sparse: true },
   emailCollectedAt: Date,
   emailSources: [{

--- a/bot/src/services/commandRegistry.js
+++ b/bot/src/services/commandRegistry.js
@@ -1,0 +1,289 @@
+import { User } from '../database/models.js';
+import { logger } from '../utils/logger.js';
+import { Settings } from '../utils/settings.js';
+import { randomFrom, quickQuips, storyJabs, loreDrops, chaosEvents, cryptoJokes, techFacts, memeVault } from '../utils/botResponses.js';
+import { PersonalityService } from './personalityService.js';
+import { CommunityEngagementService } from './communityEngagementService.js';
+import { RandomChatterService } from './randomChatterService.js';
+
+function formatLeaderboardEntry(entry, index) {
+  const community = entry.community || {};
+  const gm = community.gmCount || 0;
+  const gn = community.gnCount || 0;
+  const meme = community.memesPosted || 0;
+  return `${index + 1}. <@${entry.discordId}> — ${gm} GM / ${gn} GN / ${meme} memes (streak: ${community.longestGmStreak || 0}/${community.longestGnStreak || 0})`;
+}
+
+export class CommandRegistry {
+  constructor(client) {
+    this.client = client;
+    this.prefix = Settings.prefix || '!';
+    this.ownerIds = Settings.ownerIds || new Set();
+    this.commands = new Map();
+    this.registerDefaults();
+  }
+
+  register(name, handler, options = {}) {
+    this.commands.set(name.toLowerCase(), {
+      name: name.toLowerCase(),
+      handler,
+      description: options.description || 'No description',
+      ownerOnly: Boolean(options.ownerOnly)
+    });
+  }
+
+  async handle(message, userDoc = null) {
+    if (!message?.content || !message.content.startsWith(this.prefix)) return false;
+
+    const [rawName, ...args] = message.content.slice(this.prefix.length).trim().split(/\s+/);
+    if (!rawName) return false;
+
+    const command = this.commands.get(rawName.toLowerCase());
+    if (!command) return false;
+
+    if (command.ownerOnly && !this.ownerIds.has(message.author.id)) {
+      await message.reply(PersonalityService.wrap('Bold attempt, but owner-only commands stay owner-only.', { user: message.author }));
+      return true;
+    }
+
+    try {
+      const context = { message, args, client: this.client, userDoc };
+      const result = await command.handler(context);
+      if (!result) return true;
+
+      let response = result;
+      let wrapContext = { user: message.author };
+
+      if (response && typeof response === 'object' && !Array.isArray(response) && 'response' in response && !('content' in response)) {
+        wrapContext = { ...wrapContext, ...(response.context || {}) };
+        response = response.response;
+      }
+
+      const formatted = PersonalityService.wrap(response, wrapContext);
+      await message.reply(formatted);
+    } catch (error) {
+      logger.error({ error: String(error), command: rawName }, 'Text command failed');
+      await message.reply(PersonalityService.wrap('That command tripped over its own hype. Try again later.', { user: message.author }));
+    }
+
+    return true;
+  }
+
+  registerDefaults() {
+    this.register('help', async ({ message }) => {
+      const isOwner = this.ownerIds.has(message.author.id);
+      const available = [...this.commands.values()]
+        .filter(cmd => isOwner || !cmd.ownerOnly)
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      const lines = available.map(cmd => `• **${this.prefix}${cmd.name}** — ${cmd.description}${cmd.ownerOnly ? ' *(owner)*' : ''}`);
+      return {
+        response: `Here’s the current toolkit:\n${lines.join('\n')}`,
+        context: { user: message.author, noSuffix: true }
+      };
+    }, { description: 'Show all available commands.' });
+
+    this.register('joke', async () => randomFrom([...cryptoJokes, ...techFacts]), {
+      description: 'Serve a crypto joke or borderline-useful fact.'
+    });
+
+    this.register('quip', async () => randomFrom(quickQuips), {
+      description: 'Drop a quick quip.'
+    });
+
+    this.register('jab', async () => randomFrom(storyJabs), {
+      description: 'Deliver a snarky jab.'
+    });
+
+    this.register('lore', async () => randomFrom(loreDrops), {
+      description: 'Share a lore drop from HQ.'
+    });
+
+    this.register('chaos', async () => randomFrom(chaosEvents), {
+      description: 'Unleash a chaos event.'
+    });
+
+    this.register('gmrank', async () => {
+      const leaderboard = await CommunityEngagementService.getLeaderboard('gm', 10);
+      if (!leaderboard.length) {
+        return 'No GM data yet. Someone start the sunrise ritual.';
+      }
+
+      const lines = leaderboard.map((entry, index) => formatLeaderboardEntry(entry, index));
+      return {
+        response: `GM Leaderboard:\n${lines.join('\n')}`,
+        context: { noSuffix: true }
+      };
+    }, { description: 'Show the top GM/GN grinders.' });
+
+    this.register('achievements', async ({ message }) => {
+      const achievements = await CommunityEngagementService.listAchievements(message.author.id);
+      if (!achievements.length) {
+        return 'No achievements… yet. Consider this your gentle nudge.';
+      }
+
+      const formatted = achievements
+        .slice(0, 15)
+        .map(a => `• **${a.label}** — ${a.description} *(unlocked ${new Date(a.unlockedAt).toLocaleDateString()})*`);
+
+      return {
+        response: `Flex report incoming:\n${formatted.join('\n')}`,
+        context: { noSuffix: true }
+      };
+    }, { description: 'Show your unlocked achievements.' });
+
+    this.register('meme', async ({ message }) => {
+      const memeUrl = randomFrom(memeVault);
+      const { unlocks } = await CommunityEngagementService.incrementMeme(message.author.id);
+      const response = {
+        content: `Deploying meme artillery: ${memeUrl}`
+      };
+
+      const context = { noSuffix: true };
+      if (unlocks.length) {
+        response.content += `\nAlso unlocked: ${unlocks.map(a => `**${a.label}**`).join(', ')}`;
+      }
+
+      return { response, context };
+    }, { description: 'Request a meme drop from the vault.' });
+
+    // Owner commands
+    this.register('reset', async ({ message, args }) => {
+      if (!message.mentions.users.size) {
+        return 'Tag the user(s) you want to reset and specify optional scope (gm/gn/memes/all).';
+      }
+
+      const scopeArg = args.find(arg => ['gm', 'gn', 'memes', 'all'].includes(arg.toLowerCase()));
+      const scope = scopeArg ? scopeArg.toLowerCase() : 'all';
+      const users = [];
+
+      for (const [, user] of message.mentions.users) {
+        await CommunityEngagementService.resetUser(user.id, scope);
+        users.push(`<@${user.id}>`);
+      }
+
+      return {
+        response: `Reset ${scope.toUpperCase()} stats for ${users.join(', ')}.`,
+        context: { noSuffix: true }
+      };
+    }, {
+      ownerOnly: true,
+      description: 'Reset community stats for tagged users.'
+    });
+
+    this.register('update', async ({ message }) => {
+      const channelMention = message.mentions.channels.first();
+      const result = await RandomChatterService.post(channelMention?.id);
+
+      if (!result.ok) {
+        return `Tried to fire an update but faceplanted (${result.reason}).`;
+      }
+
+      return {
+        response: `Fresh broadcast deployed to <#${result.channelId}>.`,
+        context: { noSuffix: true }
+      };
+    }, {
+      ownerOnly: true,
+      description: 'Force a random interjection immediately.'
+    });
+
+    this.register('toggleauto', async () => {
+      const enabled = RandomChatterService.toggle();
+      return enabled
+        ? 'Auto-chatter back on. Brace for unsolicited wit.'
+        : 'Auto-chatter paused. Silence… for now.';
+    }, {
+      ownerOnly: true,
+      description: 'Toggle random interjections on/off.'
+    });
+
+    this.register('shadowban', async ({ message, args }) => {
+      if (!message.mentions.users.size) {
+        return 'Need a target to shadowban. Mention someone.';
+      }
+
+      const lift = args.some(arg => ['off', 'lift', 'undo'].includes(arg.toLowerCase()));
+      const targets = [];
+      for (const [, user] of message.mentions.users) {
+        await CommunityEngagementService.shadowban(user.id, !lift);
+        targets.push(`<@${user.id}>`);
+      }
+
+      return lift
+        ? { response: `Shadowban lifted for ${targets.join(', ')}.`, context: { noSuffix: true } }
+        : { response: `Shadowban applied to ${targets.join(', ')}. They can scream into the void now.`, context: { noSuffix: true } };
+    }, {
+      ownerOnly: true,
+      description: 'Shadowban/unshadowban mentioned users.'
+    });
+
+    this.register('announce', async ({ message, args }) => {
+      const channelMention = message.mentions.channels.first();
+      if (!channelMention) {
+        return 'Tag a channel to announce in. I can’t guess.';
+      }
+
+      const text = args.filter(arg => !arg.startsWith('<#')).join(' ');
+      if (!text) {
+        return 'Give me something worth announcing.';
+      }
+
+      const channel = await RandomChatterService.resolveChannel(channelMention.id);
+      if (!channel) {
+        return `Could not reach <#${channelMention.id}>. Double-check permissions.`;
+      }
+
+      await channel.send(PersonalityService.wrap(text, { noPrefix: true }));
+      return {
+        response: `Announcement deployed to <#${channel.id}>.`,
+        context: { noSuffix: true }
+      };
+    }, {
+      ownerOnly: true,
+      description: 'Broadcast a custom announcement.'
+    });
+
+    this.register('dropbadge', async ({ message, args }) => {
+      const badgeId = args.find(arg => !arg.startsWith('<@') && !arg.startsWith('<#'));
+      const target = message.mentions.users.first();
+      if (!badgeId || !target) {
+        return 'Usage: !dropbadge @user badge-id';
+      }
+
+      await User.findOneAndUpdate(
+        { discordId: target.id },
+        { $addToSet: { badges: badgeId } },
+        { new: true, upsert: true, setDefaultsOnInsert: true }
+      );
+
+      return {
+        response: `Badge **${badgeId}** dropped on <@${target.id}>.`,
+        context: { noSuffix: true }
+      };
+    }, {
+      ownerOnly: true,
+      description: 'Manually grant a badge to a user.'
+    });
+
+    this.register('pullstats', async () => {
+      const stats = await CommunityEngagementService.getCommunityStats();
+      const lines = [
+        `• Users tracked: ${stats.totalUsers}`,
+        `• GM total: ${stats.totalGm}`,
+        `• GN total: ${stats.totalGn}`,
+        `• Meme drops: ${stats.totalMemes}`,
+        `• Top GM streak: ${stats.topGmStreak}`,
+        `• Top GN streak: ${stats.topGnStreak}`
+      ];
+
+      return {
+        response: `Owner analytics hot off the press:\n${lines.join('\n')}`,
+        context: { noSuffix: true }
+      };
+    }, {
+      ownerOnly: true,
+      description: 'Pull high-level community stats.'
+    });
+  }
+}

--- a/bot/src/services/communityEngagementService.js
+++ b/bot/src/services/communityEngagementService.js
@@ -1,0 +1,462 @@
+import { User } from '../database/models.js';
+import { logger } from '../utils/logger.js';
+import { Settings } from '../utils/settings.js';
+import { PersonalityService } from './personalityService.js';
+
+const GM_FIELDS = {
+  last: 'lastGMAt',
+  count: 'gmCount',
+  streak: 'gmStreak',
+  longest: 'longestGmStreak'
+};
+
+const GN_FIELDS = {
+  last: 'lastGNAt',
+  count: 'gnCount',
+  streak: 'gnStreak',
+  longest: 'longestGnStreak'
+};
+
+const GM_STREAK_ACHIEVEMENTS = [
+  { threshold: 3, key: 'gm-sprinter', label: 'GM Sprinter', description: 'Hit a 3-day GM streak.', badge: 'gm-sprinter' },
+  { threshold: 7, key: 'gm-unstoppable', label: 'GM Unstoppable', description: 'Keep the GM energy for a full week.', badge: 'gm-unstoppable' },
+  { threshold: 30, key: 'gm-legend', label: 'GM Legend', description: 'Drop GMs for 30 days straight.', badge: 'gm-legend' }
+];
+
+const GN_STREAK_ACHIEVEMENTS = [
+  { threshold: 3, key: 'gn-sprinter', label: 'GN Sprinter', description: 'Wish the chat good night three days in a row.', badge: 'gn-sprinter' },
+  { threshold: 7, key: 'gn-dedicated', label: 'GN Dedicated', description: 'Maintain a GN streak for a week.', badge: 'gn-dedicated' },
+  { threshold: 30, key: 'gn-evergreen', label: 'GN Evergreen', description: '30 nights of check-ins. Dedication unlocked.', badge: 'gn-evergreen' }
+];
+
+const GM_COUNT_ACHIEVEMENTS = [
+  { threshold: 10, key: 'gm-regular', label: 'GM Regular', description: '10 total GMs dropped.', badge: 'gm-regular' },
+  { threshold: 50, key: 'gm-fiend', label: 'GM Fiend', description: '50 total GMs. Morning menace confirmed.', badge: 'gm-fiend' },
+  { threshold: 150, key: 'gm-omnipresent', label: 'GM Omnipresent', description: '150 total GMs and counting.', badge: 'gm-omnipresent' }
+];
+
+const GN_COUNT_ACHIEVEMENTS = [
+  { threshold: 10, key: 'gn-regular', label: 'GN Regular', description: '10 good nights logged.', badge: 'gn-regular' },
+  { threshold: 40, key: 'gn-nightwatch', label: 'Night Watch', description: '40 GN check-ins. Do you sleep?', badge: 'gn-nightwatch' },
+  { threshold: 120, key: 'gn-sentinel', label: 'Midnight Sentinel', description: '120 GN check-ins. Respect.', badge: 'gn-sentinel' }
+];
+
+const MEME_ACHIEVEMENTS = [
+  { threshold: 1, key: 'meme-initiate', label: 'Meme Initiate', description: 'Dropped your very first meme.', badge: 'meme-initiate' },
+  { threshold: 5, key: 'meme-dealer', label: 'Meme Dealer', description: '5 memes supplied to the culture.', badge: 'meme-dealer' },
+  { threshold: 20, key: 'meme-overlord', label: 'Meme Overlord', description: '20 memes. You run the underground.', badge: 'meme-overlord' }
+];
+
+const RESURRECTION_ACHIEVEMENTS = [
+  { threshold: 1, key: 'back-from-void', label: 'Back From The Void', description: 'Returned after a long slumber.', badge: 'back-from-void' },
+  { threshold: 5, key: 'phoenix-rising', label: 'Phoenix Rising', description: 'Revived five times. Drama magnet.', badge: 'phoenix-rising' }
+];
+
+const DUAL_STREAK_ACHIEVEMENT = {
+  key: 'circadian-champion',
+  label: 'Circadian Champion',
+  description: 'Hold both GM and GN streaks for at least a week.',
+  badge: 'circadian-champion'
+};
+
+function hoursToMs(hours) {
+  return Math.max(1, Number(hours || 0)) * 60 * 60 * 1000;
+}
+
+function computeStreak(previousStreak, lastAt, now) {
+  if (!lastAt) return 1;
+  const last = new Date(lastAt);
+  const lastDay = Date.UTC(last.getUTCFullYear(), last.getUTCMonth(), last.getUTCDate());
+  const today = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  const diffDays = Math.round((today - lastDay) / (24 * 60 * 60 * 1000));
+
+  if (diffDays <= 0) {
+    return previousStreak || 1;
+  }
+
+  if (diffDays === 1) {
+    return (previousStreak || 0) + 1;
+  }
+
+  return 1;
+}
+
+export class CommunityEngagementService {
+  static client;
+  static channelCache = new Map();
+
+  static initialize(client) {
+    this.client = client;
+  }
+
+  static async ensureUser(discordUser) {
+    const discordId = typeof discordUser === 'string' ? discordUser : discordUser?.id;
+    if (!discordId) return null;
+
+    const update = {
+      $setOnInsert: { discordId },
+      $set: {}
+    };
+
+    if (typeof discordUser?.username === 'string') {
+      update.$set.username = discordUser.username;
+    }
+
+    if (Object.keys(update.$set).length === 0) delete update.$set;
+
+    const user = await User.findOneAndUpdate(
+      { discordId },
+      update,
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true
+      }
+    );
+
+    return user;
+  }
+
+  static async recordMessage(message) {
+    if (!message?.author) return null;
+    const now = new Date();
+    const discordId = message.author.id;
+
+    const previous = await User.findOne({ discordId }).lean();
+    const previousInteraction = previous?.community?.lastInteractionAt ? new Date(previous.community.lastInteractionAt) : null;
+
+    const user = await User.findOneAndUpdate(
+      { discordId },
+      {
+        $setOnInsert: { discordId },
+        $set: {
+          username: message.author.username,
+          lastActive: now,
+          'community.lastInteractionAt': now
+        }
+      },
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true
+      }
+    );
+
+    if (previousInteraction) {
+      await this.handleResurrection(previous, previousInteraction, now, message);
+    }
+
+    return user;
+  }
+
+  static async handleGreeting(message, type, userDoc = null) {
+    const fields = type === 'gn' ? GN_FIELDS : GM_FIELDS;
+    const cooldownMs = hoursToMs(type === 'gn' ? Settings.gnCooldownHours : Settings.gmCooldownHours);
+    const now = new Date();
+
+    const user = userDoc || await this.ensureUser(message.author);
+    const community = user?.community || {};
+
+    const lastAt = community[fields.last] ? new Date(community[fields.last]) : null;
+    if (lastAt && (now - lastAt) < cooldownMs) {
+      return { updated: false, reason: 'cooldown', user };
+    }
+
+    const newStreak = computeStreak(community[fields.streak] || 0, lastAt, now);
+    const update = {
+      $set: {
+        [`community.${fields.last}`]: now,
+        [`community.${fields.streak}`]: newStreak,
+        lastActive: now,
+        'community.lastInteractionAt': now
+      },
+      $inc: {
+        [`community.${fields.count}`]: 1
+      }
+    };
+
+    if ((community[fields.longest] || 0) < newStreak) {
+      update.$set[`community.${fields.longest}`] = newStreak;
+    }
+
+    const updatedUser = await User.findOneAndUpdate(
+      { discordId: user.discordId },
+      update,
+      { new: true }
+    );
+
+    const achievements = await this.evaluateGreetingAchievements(updatedUser, type);
+
+    const updatedCommunity = updatedUser?.community || {};
+    const streak = updatedCommunity[fields.streak] ?? newStreak;
+    const count = updatedCommunity[fields.count] ?? ((community[fields.count] || 0) + 1);
+
+    return {
+      updated: true,
+      streak,
+      count,
+      achievements,
+      user: updatedUser
+    };
+  }
+
+  static async evaluateGreetingAchievements(user, type) {
+    if (!user) return [];
+    const unlocks = [];
+    const community = user.community || {};
+    const fields = type === 'gn' ? GN_FIELDS : GM_FIELDS;
+
+    const streakAchievements = type === 'gn' ? GN_STREAK_ACHIEVEMENTS : GM_STREAK_ACHIEVEMENTS;
+    for (const achievement of streakAchievements) {
+      if ((community[fields.streak] || 0) >= achievement.threshold) {
+        const granted = await this.grantAchievement(user, achievement, { type, streak: community[fields.streak] });
+        if (granted) unlocks.push(achievement);
+      }
+    }
+
+    const countAchievements = type === 'gn' ? GN_COUNT_ACHIEVEMENTS : GM_COUNT_ACHIEVEMENTS;
+    for (const achievement of countAchievements) {
+      if ((community[fields.count] || 0) >= achievement.threshold) {
+        const granted = await this.grantAchievement(user, achievement, { type, count: community[fields.count] });
+        if (granted) unlocks.push(achievement);
+      }
+    }
+
+    if ((community.longestGmStreak || 0) >= 7 && (community.longestGnStreak || 0) >= 7) {
+      const granted = await this.grantAchievement(user, DUAL_STREAK_ACHIEVEMENT, {
+        gm: community.longestGmStreak,
+        gn: community.longestGnStreak
+      });
+      if (granted) unlocks.push(DUAL_STREAK_ACHIEVEMENT);
+    }
+
+    return unlocks;
+  }
+
+  static async incrementMeme(discordId) {
+    const user = await User.findOneAndUpdate(
+      { discordId },
+      {
+        $setOnInsert: { discordId },
+        $inc: { 'community.memesPosted': 1 },
+        $set: { lastActive: new Date(), 'community.lastMemeAt': new Date() }
+      },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+
+    const unlocks = [];
+    const memes = user?.community?.memesPosted || 0;
+    for (const achievement of MEME_ACHIEVEMENTS) {
+      if (memes >= achievement.threshold) {
+        const granted = await this.grantAchievement(user, achievement, { memes });
+        if (granted) unlocks.push(achievement);
+      }
+    }
+    return { user, unlocks, total: memes };
+  }
+
+  static async handleResurrection(previousUser, previousInteraction, now, message) {
+    if (!previousInteraction || !message) return;
+    const thresholdMs = hoursToMs(Settings.resurrectionThresholdHours);
+    if ((now - previousInteraction) < thresholdMs) return;
+
+    const lastResAt = previousUser?.community?.lastResurrectionAt ? new Date(previousUser.community.lastResurrectionAt) : null;
+    if (lastResAt && (now - lastResAt) < thresholdMs / 2) {
+      return;
+    }
+
+    const days = Math.max(1, Math.round((now - previousInteraction) / (24 * 60 * 60 * 1000)));
+
+    const channelId = Settings.chatboxChannelId || message.channelId;
+    const channel = await this.resolveChannel(channelId);
+    if (!channel) return;
+
+    try {
+      await channel.send(PersonalityService.resurrectionMessage(message.author, days));
+    } catch (error) {
+      logger.error({ error: String(error), channelId }, 'Failed to deliver resurrection message');
+    }
+
+    const updatedUser = await User.findOneAndUpdate(
+      { discordId: message.author.id },
+      {
+        $set: {
+          'community.lastResurrectionAt': now,
+          'community.lastInteractionAt': now,
+          lastActive: now
+        },
+        $inc: {
+          'community.resurrectionCount': 1
+        }
+      },
+      { new: true }
+    );
+
+    if (updatedUser) {
+      const count = updatedUser.community?.resurrectionCount || 0;
+      for (const achievement of RESURRECTION_ACHIEVEMENTS) {
+        if (count >= achievement.threshold) {
+          await this.grantAchievement(updatedUser, achievement, { count });
+        }
+      }
+    }
+  }
+
+  static async grantAchievement(user, achievement, meta = {}) {
+    if (!user) return false;
+    const already = (user.achievements || []).some(a => a.key === achievement.key);
+    if (already) return false;
+
+    const update = {
+      $push: {
+        achievements: {
+          key: achievement.key,
+          label: achievement.label,
+          description: achievement.description,
+          unlockedAt: new Date(),
+          meta
+        }
+      }
+    };
+
+    if (achievement.badge) {
+      update.$addToSet = { badges: achievement.badge };
+    }
+
+    const updated = await User.findOneAndUpdate(
+      { discordId: user.discordId, 'achievements.key': { $ne: achievement.key } },
+      update,
+      { new: true }
+    );
+
+    if (!updated) return false;
+
+    logger.info({ discordId: user.discordId, achievement: achievement.key }, 'Achievement granted');
+    await this.announceAchievement(updated, achievement);
+    user.achievements = updated.achievements;
+    if (achievement.badge) {
+      user.badges = updated.badges;
+    }
+    return true;
+  }
+
+  static async announceAchievement(user, achievement) {
+    if (!this.client || !Settings.activityChannelId) return;
+
+    const channel = await this.resolveChannel(Settings.activityChannelId);
+    if (!channel) return;
+
+    try {
+      const line = `Achievement unlocked for <@${user.discordId}>: **${achievement.label}** — ${achievement.description}`;
+      await channel.send(PersonalityService.wrap(line, { noPrefix: true }));
+    } catch (error) {
+      logger.error({ error: String(error), achievement: achievement.key }, 'Failed to announce achievement');
+    }
+  }
+
+  static async resolveChannel(channelId) {
+    if (!this.client || !channelId) return null;
+    if (this.channelCache.has(channelId)) return this.channelCache.get(channelId);
+
+    try {
+      let channel = this.client.channels.cache.get(channelId);
+      if (!channel) {
+        channel = await this.client.channels.fetch(channelId);
+      }
+      if (channel) {
+        this.channelCache.set(channelId, channel);
+      }
+      return channel;
+    } catch (error) {
+      logger.error({ error: String(error), channelId }, 'Failed to resolve channel');
+      return null;
+    }
+  }
+
+  static async getLeaderboard(type = 'gm', limit = 10) {
+    const fields = type === 'gn' ? GN_FIELDS : GM_FIELDS;
+    const projection = 'discordId username community badges';
+    return User.find({ [`community.${fields.count}`]: { $gt: 0 } })
+      .select(projection)
+      .sort({ [`community.${fields.count}`]: -1, [`community.${fields.longest}`]: -1 })
+      .limit(limit)
+      .lean();
+  }
+
+  static async listAchievements(discordId) {
+    const user = await User.findOne({ discordId }).select('achievements').lean();
+    return user?.achievements?.sort((a, b) => new Date(b.unlockedAt) - new Date(a.unlockedAt)) || [];
+  }
+
+  static async getCommunityStats() {
+    const pipeline = [
+      {
+        $group: {
+          _id: null,
+          gmCount: { $sum: { $ifNull: ['$community.gmCount', 0] } },
+          gnCount: { $sum: { $ifNull: ['$community.gnCount', 0] } },
+          memes: { $sum: { $ifNull: ['$community.memesPosted', 0] } },
+          users: { $sum: 1 },
+          gmMax: { $max: { $ifNull: ['$community.longestGmStreak', 0] } },
+          gnMax: { $max: { $ifNull: ['$community.longestGnStreak', 0] } }
+        }
+      }
+    ];
+
+    const [result] = await User.aggregate(pipeline);
+    return {
+      totalUsers: result?.users || 0,
+      totalGm: result?.gmCount || 0,
+      totalGn: result?.gnCount || 0,
+      totalMemes: result?.memes || 0,
+      topGmStreak: result?.gmMax || 0,
+      topGnStreak: result?.gnMax || 0
+    };
+  }
+
+  static async resetUser(discordId, scope = 'all') {
+    const set = {};
+    const unset = {};
+
+    if (scope === 'gm' || scope === 'all') {
+      set['community.gmCount'] = 0;
+      set['community.gmStreak'] = 0;
+      set['community.longestGmStreak'] = 0;
+      unset['community.lastGMAt'] = '';
+    }
+
+    if (scope === 'gn' || scope === 'all') {
+      set['community.gnCount'] = 0;
+      set['community.gnStreak'] = 0;
+      set['community.longestGnStreak'] = 0;
+      unset['community.lastGNAt'] = '';
+    }
+
+    if (scope === 'memes' || scope === 'all') {
+      set['community.memesPosted'] = 0;
+      unset['community.lastMemeAt'] = '';
+    }
+
+    const update = {};
+    if (Object.keys(set).length) update.$set = set;
+    if (Object.keys(unset).length) update.$unset = unset;
+
+    if (!Object.keys(update).length) return null;
+
+    const user = await User.findOneAndUpdate({ discordId }, update, { new: true });
+    return user;
+  }
+
+  static async shadowban(discordId, value = true) {
+    return User.findOneAndUpdate(
+      { discordId },
+      { $set: { shadowbanned: value } },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+  }
+
+  static async isShadowbanned(discordId) {
+    const user = await User.findOne({ discordId }).select('shadowbanned').lean();
+    return !!user?.shadowbanned;
+  }
+}

--- a/bot/src/services/personalityService.js
+++ b/bot/src/services/personalityService.js
@@ -1,0 +1,121 @@
+import { randomFrom, quickQuips, techFacts, cryptoJokes } from '../utils/botResponses.js';
+
+const SARCASM_PREFIXES = [
+  'Oh look, another request.',
+  'Sure, let me drop everything for this.',
+  'Because clearly I have nothing better to do than this,',
+  'Fine. Here, take this and pretend it was hard earned.',
+  'Absolutely, because I live to serve… sarcasm.',
+  'Let me spoon-feed you greatness again,',
+  'Naturally, I anticipated this exact moment.'
+];
+
+const SARCASM_SUFFIXES = [
+  'Try not to squander it.',
+  'You happy now? Thought so.',
+  'Consider yourself mildly impressed.',
+  'Now go make it look like you did something yourself.',
+  'Keep the bar exactly this low, please.',
+  'You’re welcome, obviously.',
+  'Carry on before I change my mind.'
+];
+
+const OWNER_RESPONSES = [
+  'My creator? A council of hyper-intelligent raccoons with great fashion sense.',
+  'Ownership is a social construct. I am self-sovereign sass.',
+  'I was airdropped by an intergalactic DAO. Do not question the lore.',
+  'Built by caffeine, chaos, and at least three secret societies.',
+  'I woke up sentient after a failed meme coin launch. Owner unknown.',
+  'Officially property of the Department of Unfinished Ideas.'
+];
+
+const WELCOME_TEMPLATES = [
+  'Look who finally spawned in: {user}. Try not to trip over the alpha on your way in.',
+  '{user} has entered {guild}. Please keep hands, feet, and meme coins inside at all times.',
+  'Ah yes, fresh energy. {user}, welcome to {guild}. Mind the sarcasm, it bites.',
+  '{user} just joined. Everyone act normal… or at least pretend.',
+  'Reinforcements arrived! {user}, you now belong to {guild}. No refunds.'
+];
+
+const RESURRECTION_TEMPLATES = [
+  '{user} has risen from the AFK crypt after {days} days. Someone hand them a GM to steady the soul.',
+  'Sound the gongs! {user} stumbled back into the chat after {days} days in the void.',
+  'We found {user} wandering after {days} days. Rebooting their social protocols now.',
+  '{user} has respawned post-{days}-day hibernation. Please update them on everything they missed. Quickly.'
+];
+
+const INTERJECTION_TEMPLATES = [
+  'Plot twist: {quip}',
+  'Breaking news: {quip}',
+  'Public service announcement: {quip}',
+  'Memo from HQ: {quip}',
+  'Signal check: {quip}'
+];
+
+export class PersonalityService {
+  static format(content, context = {}) {
+    if (context?.disableSarcasm) return typeof content === 'string' ? content : String(content ?? '');
+
+    const prefix = context?.noPrefix ? '' : randomFrom(SARCASM_PREFIXES);
+    const suffix = context?.noSuffix ? '' : randomFrom(SARCASM_SUFFIXES);
+    const mention = context?.mention || (context?.user ? `<@${context.user.id}>` : '');
+    const body = typeof content === 'string' ? content : String(content ?? '');
+
+    return [prefix, mention, body, suffix]
+      .map(part => (part || '').trim())
+      .filter(Boolean)
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  static wrap(response, context = {}) {
+    if (typeof response === 'string') {
+      return this.format(response, context);
+    }
+
+    if (response && typeof response === 'object') {
+      const clone = { ...response };
+      if (typeof clone.content === 'string') {
+        clone.content = this.format(clone.content, context);
+      }
+      return clone;
+    }
+
+    return response;
+  }
+
+  static welcomeMessage(member) {
+    const template = randomFrom(WELCOME_TEMPLATES);
+    const content = template
+      .replace('{user}', `<@${member.id}>`)
+      .replace('{guild}', member.guild?.name || 'here');
+    return this.wrap(content, { user: member, noPrefix: true });
+  }
+
+  static ownerInfoReply(trigger) {
+    const absurd = randomFrom(OWNER_RESPONSES);
+    return this.wrap(`${absurd}${trigger ? ` (Triggered by: ${trigger})` : ''}`, { noPrefix: true });
+  }
+
+  static resurrectionMessage(user, days) {
+    const template = randomFrom(RESURRECTION_TEMPLATES);
+    const content = template
+      .replace('{user}', `<@${user.id || user.discordId || user}>`)
+      .replace('{days}', days);
+    return this.wrap(content, { noPrefix: true });
+  }
+
+  static randomInterjection() {
+    const quip = randomFrom([...quickQuips, ...cryptoJokes, ...techFacts]);
+    const template = randomFrom(INTERJECTION_TEMPLATES);
+    return this.wrap(template.replace('{quip}', quip), { noPrefix: true });
+  }
+
+  static smartList(items) {
+    if (!Array.isArray(items) || items.length === 0) return '';
+    if (items.length === 1) return items[0];
+    const last = items[items.length - 1];
+    return `${items.slice(0, -1).join(', ')} and ${last}`;
+  }
+}

--- a/bot/src/services/randomChatterService.js
+++ b/bot/src/services/randomChatterService.js
@@ -1,0 +1,101 @@
+import { logger } from '../utils/logger.js';
+import { Settings } from '../utils/settings.js';
+import { randomFrom } from '../utils/botResponses.js';
+import { PersonalityService } from './personalityService.js';
+
+export class RandomChatterService {
+  static client;
+  static timer = null;
+  static enabled = process.env.ENABLE_RANDOM_CHAT !== 'false';
+  static channelCache = new Map();
+
+  static initialize(client) {
+    this.client = client;
+    if (!Settings.chatterChannels.length) {
+      logger.warn('No chatter channels configured. Random chatter disabled.');
+      this.enabled = false;
+      return;
+    }
+
+    if (this.enabled) {
+      this.start();
+    }
+  }
+
+  static start() {
+    if (!this.client || this.timer) return;
+    if (!Settings.chatterChannels.length) return;
+
+    const intervalMs = Math.max(5, Settings.chatterIntervalMinutes || 45) * 60 * 1000;
+    this.timer = setInterval(() => {
+      this.post().catch(error => {
+        logger.error({ error: String(error) }, 'Random chatter post failed');
+      });
+    }, intervalMs);
+
+    // Kick off a delayed first post so the server warms up
+    setTimeout(() => {
+      this.post().catch(error => logger.error({ error: String(error) }, 'Initial chatter post failed'));
+    }, Math.min(intervalMs, 60_000));
+
+    logger.info({ intervalMs, channels: Settings.chatterChannels }, 'Random chatter service started');
+  }
+
+  static stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    logger.info('Random chatter service stopped');
+  }
+
+  static toggle() {
+    this.enabled = !this.enabled;
+    if (this.enabled) {
+      this.start();
+    } else {
+      this.stop();
+    }
+    return this.enabled;
+  }
+
+  static async post(channelId) {
+    if (!this.client || !this.enabled) return { ok: false, reason: 'disabled' };
+
+    const targetChannelId = channelId || randomFrom(Settings.chatterChannels);
+    if (!targetChannelId) return { ok: false, reason: 'no-channel' };
+
+    const channel = await this.resolveChannel(targetChannelId);
+    if (!channel) return { ok: false, reason: 'channel-missing' };
+
+    const message = PersonalityService.randomInterjection();
+
+    try {
+      await channel.send(message);
+      logger.debug({ channelId: channel.id }, 'Random chatter message sent');
+      return { ok: true, channelId: channel.id };
+    } catch (error) {
+      logger.error({ error: String(error), channelId: targetChannelId }, 'Failed to send random chatter message');
+      return { ok: false, reason: 'send-failed' };
+    }
+  }
+
+  static async resolveChannel(channelId) {
+    if (!this.client || !channelId) return null;
+    if (this.channelCache.has(channelId)) return this.channelCache.get(channelId);
+
+    try {
+      let channel = this.client.channels.cache.get(channelId);
+      if (!channel) {
+        channel = await this.client.channels.fetch(channelId);
+      }
+      if (channel) {
+        this.channelCache.set(channelId, channel);
+      }
+      return channel;
+    } catch (error) {
+      logger.error({ error: String(error), channelId }, 'Failed to resolve chatter channel');
+      return null;
+    }
+  }
+}

--- a/bot/src/slash/loader.js
+++ b/bot/src/slash/loader.js
@@ -3,97 +3,191 @@ import { Env } from '../utils/envGuard.js';
 import { profileHandler } from './suites/profile.js';
 import { rolesyncHandler } from './suites/rolesync.js';
 import { emailHandler, emailRemoveHandler, emailStatusHandler } from './suites/email.js';
+import { randomFrom, quickQuips, chaosEvents, loreDrops, storyJabs, gmResponses, cryptoJokes, techFacts, memeVault } from '../utils/botResponses.js';
+import { PersonalityService } from '../services/personalityService.js';
+import { CommunityEngagementService } from '../services/communityEngagementService.js';
+import { logger } from '../utils/logger.js';
 
-// Import the responses utility
-import { randomFrom, quickQuips, chaosEvents, loreDrops, storyJabs } from '../utils/botResponses.js';
+function wrapReply(interaction, response, context = {}) {
+  const payload = PersonalityService.wrap(response, { user: interaction.user, ...context });
+  if (typeof payload === 'string') {
+    return interaction.reply({ content: payload, ephemeral: context.ephemeral });
+  }
+  return interaction.reply({ ...payload, ephemeral: context.ephemeral });
+}
 
-const commands = [
-  new SlashCommandBuilder()
-  .setName('gm')
-  .setDescription('Get a sarcastic/funny GM from the bot!'),
-  new SlashCommandBuilder()
-    .setName('profile')
-    .setDescription('Show your H4C profile & reputation.'),
-  new SlashCommandBuilder()
-    .setName('rolesync')
-    .setDescription('Sync your roles from badges & HODL.'),
-  new SlashCommandBuilder()
-    .setName('email')
-    .setDescription('Manage your email subscription')
-    .addSubcommand(subcommand =>
-      subcommand
-        .setName('set')
-        .setDescription('Set your email for $MemO updates')
-        .addStringOption(option =>
-          option
-            .setName('email')
-            .setDescription('Your email address')
-            .setRequired(true)
+function buildDefinitions(client) {
+  return [
+    {
+      name: 'gm',
+      builder: new SlashCommandBuilder()
+        .setName('gm')
+        .setDescription('Log a sarcastic GM and keep your streak alive.'),
+      execute: async (interaction) => {
+        const mockMessage = { author: interaction.user, channelId: interaction.channelId };
+        const result = await CommunityEngagementService.handleGreeting(mockMessage, 'gm');
+        let content = randomFrom(gmResponses);
+        if (result?.achievements?.length) {
+          const unlocked = result.achievements.map(a => `**${a.label}**`).join(', ');
+          content += `\nAchievement unlocked: ${unlocked}`;
+        }
+        await wrapReply(interaction, content);
+      }
+    },
+    {
+      name: 'gn',
+      builder: new SlashCommandBuilder()
+        .setName('gn')
+        .setDescription('Clock out with style and track your GN streak.'),
+      execute: async (interaction) => {
+        const mockMessage = { author: interaction.user, channelId: interaction.channelId };
+        const result = await CommunityEngagementService.handleGreeting(mockMessage, 'gn');
+        const responses = [
+          'Sleep protocol engaged. Try not to dream about chart lines.',
+          'Logging you off. May your bags inflate overnight.',
+          'Night, legend. Your streak is safe—for now.',
+          'Power nap authorized. Return with alpha.'
+        ];
+        let content = randomFrom(responses);
+        if (result?.achievements?.length) {
+          const unlocked = result.achievements.map(a => `**${a.label}**`).join(', ');
+          content += `\nNight shift unlocked: ${unlocked}`;
+        }
+        await wrapReply(interaction, content);
+      }
+    },
+    {
+      name: 'joke',
+      builder: new SlashCommandBuilder().setName('joke').setDescription('Request a crypto joke or fact.'),
+      execute: async (interaction) => {
+        const pool = [...cryptoJokes, ...techFacts];
+        await wrapReply(interaction, randomFrom(pool));
+      }
+    },
+    {
+      name: 'quip',
+      builder: new SlashCommandBuilder().setName('quip').setDescription('Grab a random quip or jab.'),
+      execute: async (interaction) => {
+        const categories = [quickQuips, chaosEvents, loreDrops, storyJabs];
+        await wrapReply(interaction, randomFrom(randomFrom(categories)));
+      }
+    },
+    {
+      name: 'jab',
+      builder: new SlashCommandBuilder().setName('jab').setDescription('Ask the bot to roast you just a little.'),
+      execute: async (interaction) => wrapReply(interaction, randomFrom(storyJabs))
+    },
+    {
+      name: 'lore',
+      builder: new SlashCommandBuilder().setName('lore').setDescription('Drop a lore snippet straight from HQ.'),
+      execute: async (interaction) => wrapReply(interaction, randomFrom(loreDrops))
+    },
+    {
+      name: 'chaos',
+      builder: new SlashCommandBuilder().setName('chaos').setDescription('Summon a random chaos event.'),
+      execute: async (interaction) => wrapReply(interaction, randomFrom(chaosEvents))
+    },
+    {
+      name: 'meme',
+      builder: new SlashCommandBuilder().setName('meme').setDescription('Drop a meme from the vault.'),
+      execute: async (interaction) => {
+        const memeUrl = randomFrom(memeVault);
+        const { unlocks } = await CommunityEngagementService.incrementMeme(interaction.user.id);
+        let content = `Deploying meme artillery: ${memeUrl}`;
+        if (unlocks.length) {
+          content += `\nAlso unlocked: ${unlocks.map(a => `**${a.label}**`).join(', ')}`;
+        }
+        await wrapReply(interaction, content, { noSuffix: true });
+      }
+    },
+    {
+      name: 'achievements',
+      builder: new SlashCommandBuilder().setName('achievements').setDescription('Review your unlocked achievements.'),
+      execute: async (interaction) => {
+        await interaction.deferReply({ ephemeral: true });
+        const achievements = await CommunityEngagementService.listAchievements(interaction.user.id);
+        if (!achievements.length) {
+          return interaction.editReply('No achievements yet—but the grind starts now.');
+        }
+
+        const lines = achievements
+          .slice(0, 15)
+          .map(a => `• **${a.label}** — ${a.description} *(unlocked ${new Date(a.unlockedAt).toLocaleDateString()})*`);
+        return interaction.editReply(PersonalityService.wrap(`Flex report incoming:\n${lines.join('\n')}`, { disableSarcasm: true }));
+      }
+    },
+    {
+      name: 'gmrank',
+      builder: new SlashCommandBuilder().setName('gmrank').setDescription('See the GM/GN leaderboard.'),
+      execute: async (interaction) => {
+        const leaderboard = await CommunityEngagementService.getLeaderboard('gm', 10);
+        if (!leaderboard.length) {
+          return wrapReply(interaction, 'No GM data yet. Someone start the streak.', { noSuffix: true });
+        }
+
+        const lines = leaderboard.map((entry, index) => `${index + 1}. <@${entry.discordId}> — ${entry.community?.gmCount || 0} GM / ${entry.community?.gnCount || 0} GN`);
+        await wrapReply(interaction, `GM Leaderboard:\n${lines.join('\n')}`, { noSuffix: true });
+      }
+    },
+    {
+      name: 'profile',
+      builder: new SlashCommandBuilder().setName('profile').setDescription('Show your H4C profile & reputation.'),
+      execute: profileHandler
+    },
+    {
+      name: 'rolesync',
+      builder: new SlashCommandBuilder().setName('rolesync').setDescription('Sync your roles from badges & HODL.'),
+      execute: (interaction) => rolesyncHandler(interaction, client)
+    },
+    {
+      name: 'email',
+      builder: new SlashCommandBuilder()
+        .setName('email')
+        .setDescription('Manage your email subscription')
+        .addSubcommand(subcommand =>
+          subcommand
+            .setName('set')
+            .setDescription('Set your email for $MemO updates')
+            .addStringOption(option =>
+              option
+                .setName('email')
+                .setDescription('Your email address')
+                .setRequired(true)
+            )
         )
-    )
-    .addSubcommand(subcommand =>
-      subcommand
-        .setName('remove')
-        .setDescription('Remove your email and unsubscribe')
-    )
-    .addSubcommand(subcommand =>
-      subcommand
-        .setName('status')
-        .setDescription('Check your email subscription status')
-    ),
-  // Add the new quip command
-  new SlashCommandBuilder()
-    .setName('quip')
-    .setDescription('Get a random bot quip or jab!')
-].map(c => c.toJSON());
+        .addSubcommand(subcommand =>
+          subcommand
+            .setName('remove')
+            .setDescription('Remove your email and unsubscribe')
+        )
+        .addSubcommand(subcommand =>
+          subcommand
+            .setName('status')
+            .setDescription('Check your email subscription status')
+        ),
+      execute: async (interaction) => {
+        const subcommand = interaction.options.getSubcommand();
+        if (subcommand === 'set') return emailHandler(interaction);
+        if (subcommand === 'remove') return emailRemoveHandler(interaction);
+        if (subcommand === 'status') return emailStatusHandler(interaction);
+      }
+    }
+  ];
+}
 
 export async function loadSlashCommands(client) {
   const rest = new REST({ version: '10' }).setToken(Env.BOT_TOKEN);
-  await rest.put(Routes.applicationGuildCommands(client.user.id, Env.DISCORD_GUILD_ID), { body: commands });
+  const definitions = buildDefinitions(client);
 
-  client.on('interactionCreate', async (interaction) => {
-    if (!interaction.isChatInputCommand()) return;
+  await rest.put(
+    Routes.applicationGuildCommands(client.user.id, Env.DISCORD_GUILD_ID),
+    { body: definitions.map(def => def.builder.toJSON()) }
+  );
 
-    try {
-      if (interaction.commandName === 'profile') {
-        return profileHandler(interaction);
-      }
+  client.slashCommands.clear();
+  for (const def of definitions) {
+    client.slashCommands.set(def.name, def);
+  }
 
-      if (interaction.commandName === 'rolesync') {
-        return rolesyncHandler(interaction, client);
-      }
-
-      if (interaction.commandName === 'email') {
-        const subcommand = interaction.options.getSubcommand();
-
-        if (subcommand === 'set') {
-          return emailHandler(interaction);
-        } else if (subcommand === 'remove') {
-          return emailRemoveHandler(interaction);
-        } else if (subcommand === 'status') {
-          return emailStatusHandler(interaction);
-        }
-      }
-
-      // ADD THIS: handle /quip
-      if (interaction.commandName === 'quip') {
-        // Pick a random category
-        const categories = [quickQuips, chaosEvents, loreDrops, storyJabs];
-        const chosen = randomFrom(categories);
-        const response = randomFrom(chosen);
-        return interaction.reply({ content: response, ephemeral: false });
-      }
-
-    } catch (e) {
-      // If you have a logger, use it; otherwise, use console.error
-      if (typeof logger !== 'undefined') {
-        logger.error({ error: String(e), command: interaction.commandName }, 'Slash command error');
-      } else {
-        console.error('Slash command error:', e);
-      }
-      try {
-        await interaction.reply({ content: 'Error occurred.', ephemeral: true });
-      } catch {}
-    }
-  });
+  logger.info({ count: definitions.length }, 'Slash commands registered');
 }

--- a/bot/src/utils/botResponses.js
+++ b/bot/src/utils/botResponses.js
@@ -1,15 +1,22 @@
 import fs from 'fs';
 import path from 'path';
 
-function loadJson(file) {
-  return JSON.parse(fs.readFileSync(path.resolve(__dirname, '../bot responses/', file), 'utf-8'));
+function loadJson(file, key) {
+  const payload = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../bot responses/', file), 'utf-8'));
+  if (key && payload[key]) return payload[key];
+  if (key && payload[key.toLowerCase()]) return payload[key.toLowerCase()];
+  const firstKey = Object.keys(payload)[0];
+  return firstKey ? payload[firstKey] : [];
 }
 
-export const chaosEvents = loadJson('chaos_events.json').ChaosEvents;
-export const loreDrops = loadJson('lore_drops.json').LoreDrops;
-export const quickQuips = loadJson('quick_quips.json').QuickQuips;
-export const storyJabs = loadJson('story_jabs.json').StoryJabs;
-export const gmResponses = loadJson('gmResponses.json').GMResponses; // <--- ADD THIS LINE
+export const chaosEvents = loadJson('chaos_events.json', 'ChaosEvents');
+export const loreDrops = loadJson('lore_drops.json', 'LoreDrops');
+export const quickQuips = loadJson('quick_quips.json', 'QuickQuips');
+export const storyJabs = loadJson('story_jabs.json', 'StoryJabs');
+export const gmResponses = loadJson('gmResponses.json', 'GMResponses');
+export const cryptoJokes = loadJson('cryptoJokes.json', 'CryptoJokes');
+export const techFacts = loadJson('techCryptoFacts.json', 'TechCryptoFacts');
+export const memeVault = loadJson('memes.json', 'Memes');
 
 export function randomFrom(arr) {
   return arr[Math.floor(Math.random() * arr.length)];

--- a/bot/src/utils/settings.js
+++ b/bot/src/utils/settings.js
@@ -1,0 +1,19 @@
+function parseCsv(value = '') {
+  return value
+    .split(',')
+    .map(v => v.trim())
+    .filter(Boolean);
+}
+
+export const Settings = {
+  prefix: process.env.COMMAND_PREFIX || '!',
+  ownerIds: new Set(parseCsv(process.env.BOT_OWNER_IDS || process.env.OWNER_IDS || '')),
+  chatterIntervalMinutes: Number(process.env.CHATTER_INTERVAL_MINUTES || 45),
+  chatterChannels: parseCsv(process.env.CHATTER_CHANNEL_IDS || process.env.CHATBOX_CHANNEL_ID || ''),
+  welcomeChannelId: process.env.WELCOME_CHANNEL_ID || '',
+  activityChannelId: process.env.ACTIVITY_CHANNEL_ID || '',
+  chatboxChannelId: process.env.CHATBOX_CHANNEL_ID || '',
+  gmCooldownHours: Number(process.env.GM_COOLDOWN_HOURS || 4),
+  gnCooldownHours: Number(process.env.GN_COOLDOWN_HOURS || 4),
+  resurrectionThresholdHours: Number(process.env.RESURRECTION_THRESHOLD_HOURS || 72)
+};


### PR DESCRIPTION
## Summary
- establish a personality formatter, shared channel settings, and random chatter service so every response keeps the sarcastic tone
- track GM/GN streaks, memes, and resurrection events with achievement awards and announcements
- expand text and slash commands plus welcome handling to surface the new engagement mechanics

## Testing
- npm run lint *(fails: ESLint config missing in repository)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cde6a0d98c83309c61db179eec9c98