### PR TITLE
Sanitize markdown output and add integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:shared": "cd shared && npm test",
     "test:bot": "cd bot && npm test",
     "test:web": "cd web && npm test",
-    "test:integration": "node tests/smoke.js && node tests/integration-award.js",
+    "test:integration": "node tests/smoke.js && node tests/integration-award.js && node tests/integration-markdown.js",
     
     "lint": "npm run lint:shared && npm run lint:bot && npm run lint:web",
     "lint:shared": "cd shared && npm run lint",

--- a/tests/integration-markdown.js
+++ b/tests/integration-markdown.js
@@ -1,0 +1,40 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const assert = require('node:assert/strict');
+const ts = require('typescript');
+
+function loadMdToHtml() {
+  const sourcePath = path.resolve(__dirname, '../web/lib/markdown.ts');
+  const source = fs.readFileSync(sourcePath, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2019,
+      esModuleInterop: true,
+    },
+    fileName: sourcePath,
+  });
+
+  const module = { exports: {} };
+  const fn = new Function('exports', 'require', 'module', '__filename', '__dirname', outputText);
+  fn(module.exports, require, module, sourcePath, path.dirname(sourcePath));
+  return module.exports.mdToHtml;
+}
+
+(async () => {
+  const mdToHtml = loadMdToHtml();
+
+  const basic = await mdToHtml('# Heading\n\nParagraph with **bold** and <em>inline HTML</em>.');
+  assert.match(basic, /<h1>Heading<\/h1>/, 'Heading should render as h1');
+  assert.match(basic, /<p>Paragraph with <strong>bold<\/strong> and <em>inline HTML<\/em>\.<\/p>/);
+
+  const sanitized = await mdToHtml('<script>alert(1)</script><p>Visible</p>');
+  assert.doesNotMatch(sanitized, /<script/i, 'Script tags should be removed');
+  assert.match(sanitized, /<p>Visible<\/p>/, 'Safe content should remain');
+
+  console.log('integration markdown ok');
+})().catch(err => {
+  console.error('integration markdown failed');
+  console.error(err);
+  process.exit(1);
+});

--- a/web/lib/markdown.ts
+++ b/web/lib/markdown.ts
@@ -1,3 +1,4 @@
+import DOMPurify from "isomorphic-dompurify";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
@@ -9,5 +10,6 @@ export async function mdToHtml(md: string): Promise<string> {
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeStringify, { allowDangerousHtml: true })
     .process(md);
-  return String(file);
+  const rendered = String(file);
+  return DOMPurify.sanitize(rendered);
 }


### PR DESCRIPTION
## Summary
- sanitize markdown output in the shared mdToHtml helper using isomorphic-dompurify
- add an integration script that validates markdown rendering and script stripping and hook it into the integration test suite

## Testing
- npm run test:integration

------
https://chatgpt.com/codex/tasks/task_e_68ce16e8dc248330901d4a26043ebbf3