### PR TITLE
Handle email signup timeout cleanup and add test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+**/node_modules/

--- a/web/components/EmailSignup.tsx
+++ b/web/components/EmailSignup.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 type EmailSignupProps = {
   className?: string;
@@ -9,10 +9,26 @@ export default function EmailSignup({ className = "" }: EmailSignupProps) {
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [message, setMessage] = useState("");
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearStatusTimeout = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      clearStatusTimeout();
+    };
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
+    clearStatusTimeout();
+
     if (!email.trim()) {
       setStatus("error");
       setMessage("Please enter your email address");
@@ -28,7 +44,7 @@ export default function EmailSignup({ className = "" }: EmailSignupProps) {
     }
 
     setStatus("loading");
-    
+
     try {
       const response = await fetch("/api/email/subscribe", {
         method: "POST",
@@ -54,9 +70,10 @@ export default function EmailSignup({ className = "" }: EmailSignupProps) {
     }
 
     // Clear status after 5 seconds
-    setTimeout(() => {
+    timeoutRef.current = setTimeout(() => {
       setStatus("idle");
       setMessage("");
+      timeoutRef.current = null;
     }, 5000);
   };
 

--- a/web/components/__tests__/EmailSignup.test.tsx
+++ b/web/components/__tests__/EmailSignup.test.tsx
@@ -1,0 +1,47 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import EmailSignup from "../EmailSignup";
+
+describe("EmailSignup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("clears the reset timeout when the component unmounts", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const { unmount } = render(<EmailSignup />);
+
+    fireEvent.change(screen.getByPlaceholderText("your@email.com"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /subscribe/i }));
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText(/thanks for subscribing/i)).toBeInTheDocument();
+
+    unmount();
+    vi.runAllTimers();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Can't perform a React state update on an unmounted component."
+      )
+    );
+  });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,8 @@
     "start": "next start -p $PORT",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "analyze": "ANALYZE=true npm run build",
     "security-check": "npm audit --audit-level=high"
   },
@@ -32,7 +34,11 @@
   "devDependencies": {
     "eslint": "^8.57.0",
     "eslint-config-next": "14.2.16",
-    "@next/bundle-analyzer": "14.2.16"
+    "@next/bundle-analyzer": "14.2.16",
+    "@testing-library/jest-dom": "^6.5.0",
+    "@testing-library/react": "^16.0.1",
+    "jsdom": "^24.1.0",
+    "vitest": "^2.1.4"
   },
   "engines": {
     "node": ">=18.18.0",

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: "./vitest.setup.ts",
+    globals: true,
+    css: true,
+  },
+  esbuild: {
+    jsx: "automatic",
+  },
+});

--- a/web/vitest.setup.ts
+++ b/web/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- store the email signup reset timeout in a ref and clear it on unmount
- add vitest configuration and testing dependencies for the web workspace
- cover the cleanup with a React Testing Library test that unmounts before the timer fires

## Testing
- npm --prefix web test *(fails: `vitest` unavailable because required packages cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce16f2fba88330907fe31f8e981439