### PR TITLE
Handle empty personality payloads in slash replies

### DIFF
--- a/bot/src/slash/loader.js
+++ b/bot/src/slash/loader.js
@@ -6,15 +6,10 @@ import { emailHandler, emailRemoveHandler, emailStatusHandler } from './suites/e
 import { randomFrom, quickQuips, chaosEvents, loreDrops, storyJabs, gmResponses, cryptoJokes, techFacts, memeVault } from '../utils/botResponses.js';
 import { PersonalityService } from '../services/personalityService.js';
 import { CommunityEngagementService } from '../services/communityEngagementService.js';
+import { createWrapReply } from './wrapReply.js';
 import { logger } from '../utils/logger.js';
 
-function wrapReply(interaction, response, context = {}) {
-  const payload = PersonalityService.wrap(response, { user: interaction.user, ...context });
-  if (typeof payload === 'string') {
-    return interaction.reply({ content: payload, ephemeral: context.ephemeral });
-  }
-  return interaction.reply({ ...payload, ephemeral: context.ephemeral });
-}
+const wrapReply = createWrapReply((response, ctx) => PersonalityService.wrap(response, ctx));
  codex/summarize-chatbot-feature-improvements-iurbcj
 
 function buildDefinitions(client) {

--- a/bot/src/slash/wrapReply.js
+++ b/bot/src/slash/wrapReply.js
@@ -1,0 +1,18 @@
+export const FALLBACK_REPLY = 'Apologies, I blanked on a comeback. Try again in a sec.';
+
+export function createWrapReply(wrapFn = (value) => value) {
+  return function wrapReply(interaction, response, context = {}) {
+    const payload = wrapFn(response, { user: interaction.user, ...context });
+    const safePayload = payload ?? FALLBACK_REPLY;
+
+    if (typeof safePayload === 'string') {
+      return interaction.reply({ content: safePayload, ephemeral: context.ephemeral });
+    }
+
+    if (safePayload && typeof safePayload === 'object') {
+      return interaction.reply({ ...safePayload, ephemeral: context.ephemeral });
+    }
+
+    return interaction.reply({ content: String(safePayload), ephemeral: context.ephemeral });
+  };
+}

--- a/bot/test/slash-loader.test.js
+++ b/bot/test/slash-loader.test.js
@@ -1,0 +1,23 @@
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWrapReply, FALLBACK_REPLY } from '../src/slash/wrapReply.js';
+
+const interactionFactory = () => ({
+  user: { id: 'user-123' },
+  reply: mock.fn(async () => {})
+});
+
+test('wrapReply falls back to a safe message when the response payload is empty', async () => {
+  const wrapReply = createWrapReply(() => undefined);
+  const interaction = interactionFactory();
+
+  await wrapReply(interaction, undefined, {});
+
+  assert.strictEqual(interaction.reply.mock.calls.length, 1);
+  const [payload] = interaction.reply.mock.calls[0].arguments;
+  assert.deepStrictEqual(payload, {
+    content: FALLBACK_REPLY,
+    ephemeral: undefined
+  });
+});


### PR DESCRIPTION
## Summary
- wrap slash command responses with a helper that defaults to a safe fallback when the personality wrapper returns nothing
- share the guarded wrapReply helper via a dedicated module for reuse and testing
- add a node:test case that simulates an empty response pool to verify the fallback reply is sent

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ce17550ed88330871aedcec8c6504a