### PR TITLE
Fix Next.js build issues blocking Render deployment

### DIFF
--- a/web/components/Article.tsx
+++ b/web/components/Article.tsx
@@ -1,20 +1,22 @@
-import type { ProcessedChartData, Section } from "@/lib/types";
+import type { ChartData, ProcessedChartData, Section } from "@/lib/types";
 import dynamic from "next/dynamic";
 import DOMPurify from "isomorphic-dompurify";
 
 const Chart = dynamic(() => import("./Chart"), { ssr: false });
+
+type ChartEntry = ChartData | ProcessedChartData;
 
 type Props = {
   title: string;
   description?: string;
   coverImage?: string | null;
   sections?: Section[];
-  charts?: ProcessedChartData[];
+  charts?: ChartEntry[];
 };
 
 export default function Article({ title, description, coverImage, sections, charts }: Props) {
   const safeSections: Section[] = Array.isArray(sections) ? sections : [];
-  const safeCharts: ProcessedChartData[] = Array.isArray(charts) ? charts : [];
+  const safeCharts: ChartEntry[] = Array.isArray(charts) ? charts : [];
 
   const toc = safeSections
     .map((s, i) => ({ i, h: s.heading?.trim() }))
@@ -53,20 +55,25 @@ export default function Article({ title, description, coverImage, sections, char
         {safeCharts.length > 0 && (
           <section className="mt-12">
             <h2>Charts &amp; Data</h2>
-            {safeCharts.map((chart, index) => (
-              <Chart
-                key={chart.id || index}
-                type={chart.type}
-                title={chart.title}
-                subtitle={chart.subtitle}
-                data={chart.data}
-                processedData={chart.processedData}
-                xKey={chart.xKey}
-                yKey={chart.yKey}
-                series={chart.series}
-                colors={chart.colors}
-              />
-            ))}
+            {safeCharts.map((chart, index) => {
+              const chartKey =
+                "id" in chart && chart.id ? chart.id : `${chart.title ?? "chart"}-${index}`;
+
+              return (
+                <Chart
+                  key={chartKey}
+                  type={chart.type}
+                  title={chart.title}
+                  subtitle={chart.subtitle}
+                  data={chart.data}
+                  processedData={"processedData" in chart ? chart.processedData : undefined}
+                  xKey={chart.xKey}
+                  yKey={chart.yKey}
+                  series={chart.series}
+                  colors={chart.colors}
+                />
+              );
+            })}
           </section>
         )}
       </article>

--- a/web/components/charts/BaseChart.tsx
+++ b/web/components/charts/BaseChart.tsx
@@ -1,16 +1,30 @@
 "use client";
 
-import type { ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import { ResponsiveContainer } from 'recharts';
 
 interface BaseChartProps {
   title: string;
   subtitle?: string;
-  children: ReactNode;
+  children: ReactElement | null;
   className?: string;
 }
 
 export function BaseChart({ title, subtitle, children, className = '' }: BaseChartProps) {
+  if (!children) {
+    return (
+      <div className={`my-8 rounded-lg border border-slate-700 bg-slate-800/50 p-6 ${className}`}>
+        <div className="mb-4">
+          <h3 className="text-xl font-semibold text-white">{title}</h3>
+          {subtitle ? <p className="mt-1 text-sm text-slate-400">{subtitle}</p> : null}
+        </div>
+        <div className="flex h-80 items-center justify-center text-sm text-slate-400">
+          Chart configuration unavailable
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={`my-8 rounded-lg border border-slate-700 bg-slate-800/50 p-6 ${className}`}>
       <div className="mb-4">

--- a/web/lib/markdown.ts
+++ b/web/lib/markdown.ts
@@ -5,9 +5,10 @@ import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import rehypeStringify from "rehype-stringify";
 
-const DOMPurify = createDOMPurify(
-  typeof window === "undefined" ? undefined : (window as unknown as Window)
-);
+const windowLike =
+  typeof window === "undefined" ? undefined : (window as unknown as typeof globalThis);
+
+const DOMPurify = createDOMPurify(windowLike);
 
 export async function mdToHtml(md: string): Promise<string> {
   const source = typeof md === "string" ? md : "";

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -2,6 +2,7 @@ export type {
   Article,
   BaseArticle,
   ChartData,
+  ProcessedChartData,
   ChartSeries,
   ChartType,
   DashboardUser,

--- a/web/types/lru-cache.d.ts
+++ b/web/types/lru-cache.d.ts
@@ -1,0 +1,19 @@
+declare module 'lru-cache' {
+  interface LRUCacheOptions<K, V> {
+    max?: number;
+    ttl?: number;
+    allowStale?: boolean;
+  }
+
+  interface SetOptions {
+    ttl?: number;
+  }
+
+  export class LRUCache<K = any, V = any> {
+    constructor(options?: LRUCacheOptions<K, V>);
+    get(key: K): V | undefined;
+    set(key: K, value: V, options?: SetOptions): void;
+    delete(key: K): void;
+    keys(): IterableIterator<K>;
+  }
+}


### PR DESCRIPTION
## Summary
- update article and chart components to support both raw and processed chart data
- add DOMPurify window shim and local lru-cache typings to satisfy the Next.js type checker
- rebuild the sitemap generator to use getServerSideProps so the production build succeeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce583880688330b64dbe7911d19061