### PR TITLE
Stabilize Render installs for web and bot workspaces

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -13,6 +13,7 @@
     "test:watch": "node --test --watch test/*.test.js"
   },
   "dependencies": {
+    "@h4c/shared": "file:../shared",
     "discord.js": "^14.16.3",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/render.yaml
+++ b/render.yaml
@@ -4,30 +4,7 @@ services:
     name: h4c-web
     env: node
     plan: starter  # Free tier
-    buildCommand: |
-      echo "=== Build Environment Info ===" &&
-      node --version &&
-      npm --version &&
-      pwd &&
-      ls -la &&
-      echo "=== Installing root dependencies ===" &&
-      npm ci --no-optional --silent --legacy-peer-deps &&
-      echo "=== Installing web dependencies ===" &&
-      cd web &&
-      pwd &&
-      ls -la &&
-      echo "Installing web deps..." &&
-      npm ci --no-optional --silent --legacy-peer-deps &&
-      echo "=== Installing TypeScript if missing ===" &&
-      npm install --save-dev typescript @types/react @types/react-dom @types/node ||
-      echo "TypeScript already installed or install failed" &&
-      echo "=== Checking content directory ===" &&
-      ls -la content/ || echo "No content directory at web level" &&
-      ls -la ../content/ || echo "No content directory at root level" &&
-      find . -name "*.json" -path "*/mega_article/*" || echo "No article JSON files found" &&
-      echo "=== Building web app ===" &&
-      npm run build &&
-      echo "=== Build Complete ==="
+    buildCommand: ./scripts/render-build.sh
     startCommand: cd web && npm start
     envVars:
       - key: NODE_ENV
@@ -48,24 +25,7 @@ services:
     name: h4c-bot
     env: node
     plan: starter  # Free tier
-    buildCommand: |
-      echo "=== Bot Build Environment ===" &&
-      node --version &&
-      npm --version &&
-      echo "=== Installing root dependencies ===" &&
-      npm ci --no-optional --silent --legacy-peer-deps &&
-      echo "=== Installing shared dependencies ===" &&
-      cd shared &&
-      npm ci --no-optional --silent --legacy-peer-deps || echo "Shared install skipped" &&
-      cd .. &&
-      echo "=== Installing bot dependencies ===" &&
-      cd bot &&
-      npm ci --no-optional --silent --legacy-peer-deps &&
-      echo "=== Checking bot files ===" &&
-      ls -la src/ &&
-      ls -la src/bot\ responses/ || echo "Bot responses dir not found, creating..." &&
-      mkdir -p src/bot\ responses/ &&
-      echo "=== Bot Build Complete ==="
+    buildCommand: ./scripts/render-worker-build.sh
     startCommand: cd bot && npm start
     envVars:
       - key: NODE_ENV

--- a/scripts/render-build.sh
+++ b/scripts/render-build.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# Render.com build script for H4C monorepo
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/render-common.sh"
+
+trap 'log "Render web build failed on line $LINENO"' ERR
+
+ensure_workspace_packages() {
+  local install_specs=()
+  local requested=("$@")
+
+  for pkg in "${requested[@]}"; do
+    if npm ls "$pkg" --depth=0 >/dev/null 2>&1; then
+      continue
+    fi
+
+    local version=""
+    if ! version=$(PKG_NAME="$pkg" node -e '
+const fs = require("fs");
+const path = require("path");
+const manifestPath = path.resolve("package.json");
+if (!fs.existsSync(manifestPath)) {
+  process.exit(1);
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+const sections = ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"];
+
+for (const section of sections) {
+  const block = manifest[section];
+  if (block && block[process.env.PKG_NAME]) {
+    process.stdout.write(String(block[process.env.PKG_NAME]));
+    process.exit(0);
+  }
+}
+
+process.exit(1);
+' 2>/dev/null); then
+      version=""
+    fi
+
+    version=${version//$'\n'/}
+
+    if [ -n "$version" ]; then
+      install_specs+=("$pkg@$version")
+    else
+      install_specs+=("$pkg")
+    fi
+  done
+
+  if [ ${#install_specs[@]} -gt 0 ]; then
+    log "Installing missing workspace packages: ${install_specs[*]}"
+    npm install --no-save --no-package-lock --no-audit --no-fund "${install_specs[@]}"
+  else
+    log "Verified required packages are already installed: ${requested[*]}"
+  fi
+}
+
+setup_npm_env
+
+create_sample_content() {
+  log "Creating sample content files..."
+
+  local targets=(
+    "content/mega_article"
+    "web/content/mega_article"
+  )
+
+  for target in "${targets[@]}"; do
+    mkdir -p "$target"
+
+    cat > "$target/01-foreword.json" <<'JSON'
+{
+  "slug": "foreword",
+  "title": "Foreword: Why Crypto, Why Now",
+  "description": "Introduction to cryptocurrency and blockchain",
+  "sections": [
+    {
+      "heading": "Welcome to Hunger4Crypto",
+      "body": "The story of cryptocurrency is a tale of trust, belief, rebellion, and reinvention. This guide cuts through the noise with playful, clear, and brutally honest insights."
+    },
+    {
+      "heading": "Why This Guide Exists",
+      "body": "When Bitcoin appeared in 2009, the world laughed. Now governments, banks, and billion dollar funds are deep in the game. If you're here, you're early enough to still matter."
+    }
+  ]
+}
+JSON
+
+    cat > "$target/02-bitcoin.json" <<'JSON'
+{
+  "slug": "bitcoin",
+  "title": "Bitcoin: The Genesis and Relentless Rise",
+  "description": "Understanding the first cryptocurrency",
+  "sections": [
+    {
+      "heading": "The Spark That Ignited a Revolution",
+      "body": "In 2008, amid financial chaos, Satoshi Nakamoto dropped a nine-page PDF that would change money forever. Bitcoin wasn't just technology; it was rebellion."
+    }
+  ]
+}
+JSON
+
+    cat > "$target/03-ethereum.json" <<'JSON'
+{
+  "slug": "ethereum",
+  "title": "Ethereum: The World Computer",
+  "description": "Smart contracts and programmable money",
+  "sections": [
+    {
+      "heading": "From Bitcoin's Shadow",
+      "body": "Vitalik Buterin saw Bitcoin's limitations and imagined bigger: a blockchain that could run smart contracts and decentralized applications."
+    }
+  ]
+}
+JSON
+
+    cat > "$target/04-algorand.json" <<'JSON'
+{
+  "slug": "algorand",
+  "title": "Algorand: The Green Speed Demon",
+  "description": "Fast, eco-friendly blockchain",
+  "sections": [
+    {
+      "heading": "The Elevator Pitch",
+      "body": "Algorand is fast, eco-friendly, and designed by MIT professor Silvio Micali. Where Bitcoin makes you wait, Algorand zips through in seconds."
+    }
+  ]
+}
+JSON
+  done
+
+  log "Sample content created"
+}
+
+log "H4C Build Script Starting"
+log "Current directory: $(pwd)"
+log "Directory contents:"
+ls -la
+log "Node version: $(node --version)"
+log "npm version: $(npm --version)"
+
+if [ -d "content/mega_article" ] || [ -d "web/content/mega_article" ]; then
+  log "Content directory exists"
+  ls -la content/mega_article/ 2>/dev/null || true
+  ls -la web/content/mega_article/ 2>/dev/null || true
+else
+  log "Content directory missing, creating sample content..."
+  create_sample_content
+fi
+
+log "Installing root dependencies"
+if [ -f "package-lock.json" ] || [ -f "npm-shrinkwrap.json" ]; then
+  if ! run_npm_install "." --omit=dev; then
+    log "Root dependency installation failed or is unnecessary, continuing"
+  fi
+else
+  log "No root lockfile detected, skipping root dependency installation"
+fi
+
+if [ -d "shared" ]; then
+  log "Installing shared dependencies"
+  if [ -f "shared/package-lock.json" ] || [ -f "shared/npm-shrinkwrap.json" ]; then
+    if ! run_npm_install "shared" --omit=dev; then
+      log "Shared dependency installation failed, continuing"
+    fi
+  else
+    log "No shared lockfile detected, skipping shared dependency installation"
+  fi
+fi
+
+log "Installing web dependencies"
+cd web
+
+if [ ! -f "next-env.d.ts" ]; then
+  log "Creating next-env.d.ts..."
+  cat <<'NEXT' > next-env.d.ts
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+NEXT
+fi
+
+previous_workspaces="${NPM_CONFIG_WORKSPACES-}"
+export NPM_CONFIG_WORKSPACES=false
+run_npm_install "." --include=dev
+if [ -n "${previous_workspaces:-}" ]; then
+  export NPM_CONFIG_WORKSPACES="$previous_workspaces"
+else
+  unset NPM_CONFIG_WORKSPACES
+fi
+ensure_workspace_packages typescript @types/react @types/react-dom @types/node
+
+log "Verifying content accessibility"
+ls -la content/mega_article/ 2>/dev/null || echo "No content dir at web level"
+ls -la ../content/mega_article/ 2>/dev/null || echo "No content dir at root level"
+
+log "Building web application"
+npm run build
+
+log "Build completed successfully"
+ls -la .next/
+
+log "H4C Build Complete"

--- a/scripts/render-common.sh
+++ b/scripts/render-common.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Shared helpers for Render build scripts. These utilities intentionally avoid
+# side effects beyond environment configuration so they can be sourced by both
+# the web and worker build pipelines.
+
+if [ "${H4C_RENDER_COMMON_SOURCED:-0}" -eq 1 ]; then
+  return 0
+fi
+
+export H4C_RENDER_COMMON_SOURCED=1
+
+log() {
+  printf '=== %s ===\n' "$*"
+}
+
+setup_npm_env() {
+  if [ "${H4C_RENDER_NPM_ENV:-0}" -eq 1 ]; then
+    return 0
+  fi
+
+  export H4C_RENDER_NPM_ENV=1
+
+  # Ensure dev dependencies are always available even when Render sets
+  # NODE_ENV=production. We also widen network timeouts so transient registry
+  # hiccups don't abort a build mid-install.
+  export NPM_CONFIG_PRODUCTION=false
+  export NPM_CONFIG_AUDIT=false
+  export NPM_CONFIG_FUND=false
+  export NPM_CONFIG_FETCH_TIMEOUT="${NPM_CONFIG_FETCH_TIMEOUT:-120000}"
+  export NPM_CONFIG_FETCH_RETRIES="${NPM_CONFIG_FETCH_RETRIES:-5}"
+  export NPM_CONFIG_FETCH_RETRY_MINTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MINTIMEOUT:-20000}"
+  export NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT:-120000}"
+  export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm}"
+}
+
+run_npm_install() {
+  setup_npm_env
+
+  local dir="$1"
+  shift || true
+  local extra_args=("$@")
+
+  local resolved_dir
+  resolved_dir=$(cd "$dir" && pwd)
+
+  local install_args=(--no-audit --no-fund "${extra_args[@]}")
+
+  if [ -f "$dir/package-lock.json" ] || [ -f "$dir/npm-shrinkwrap.json" ]; then
+    log "Installing dependencies with npm ci in $resolved_dir"
+    (cd "$dir" && npm ci "${install_args[@]}")
+  else
+    log "No lockfile found in $resolved_dir, running npm install"
+    (cd "$dir" && npm install "${install_args[@]}")
+  fi
+}
+

--- a/scripts/render-worker-build.sh
+++ b/scripts/render-worker-build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Render.com worker build script for the Discord bot
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/render-common.sh"
+
+trap 'log "Render bot build failed on line $LINENO"' ERR
+
+setup_npm_env
+
+log "H4C Bot Build Script Starting"
+log "Current directory: $(pwd)"
+log "Directory contents:"
+ls -la
+log "Node version: $(node --version)"
+log "npm version: $(npm --version)"
+
+if [ -d "shared" ]; then
+  log "Installing shared workspace dependencies"
+  run_npm_install "shared" --omit=dev
+else
+  log "Shared workspace not found, skipping install"
+fi
+
+log "Installing bot workspace dependencies"
+run_npm_install "bot" --omit=dev
+
+cd bot
+
+log "Inspecting bot source tree"
+ls -la src || true
+
+responses_dir="src/bot responses"
+if [ ! -d "$responses_dir" ]; then
+  log "Bot responses directory missing, creating placeholder"
+  mkdir -p "$responses_dir"
+fi
+ls -la "$responses_dir" || true
+
+if ! npm ls @h4c/shared --depth=0 >/dev/null 2>&1; then
+  log "Linking @h4c/shared dependency for bot runtime"
+  npm install --no-save --no-package-lock --no-audit --no-fund ../shared
+else
+  log "@h4c/shared workspace dependency already linked"
+fi
+
+log "Bot workspace ready for Render"

--- a/web/components/Article.tsx
+++ b/web/components/Article.tsx
@@ -1,20 +1,22 @@
-import type { ProcessedChartData, Section } from "@/lib/types";
+import type { ChartData, ProcessedChartData, Section } from "@/lib/types";
 import dynamic from "next/dynamic";
 import DOMPurify from "isomorphic-dompurify";
 
 const Chart = dynamic(() => import("./Chart"), { ssr: false });
+
+type ChartEntry = ChartData | ProcessedChartData;
 
 type Props = {
   title: string;
   description?: string;
   coverImage?: string | null;
   sections?: Section[];
-  charts?: ProcessedChartData[];
+  charts?: ChartEntry[];
 };
 
 export default function Article({ title, description, coverImage, sections, charts }: Props) {
   const safeSections: Section[] = Array.isArray(sections) ? sections : [];
-  const safeCharts: ProcessedChartData[] = Array.isArray(charts) ? charts : [];
+  const safeCharts: ChartEntry[] = Array.isArray(charts) ? charts : [];
 
   const toc = safeSections
     .map((s, i) => ({ i, h: s.heading?.trim() }))
@@ -53,20 +55,25 @@ export default function Article({ title, description, coverImage, sections, char
         {safeCharts.length > 0 && (
           <section className="mt-12">
             <h2>Charts &amp; Data</h2>
-            {safeCharts.map((chart, index) => (
-              <Chart
-                key={chart.id || index}
-                type={chart.type}
-                title={chart.title}
-                subtitle={chart.subtitle}
-                data={chart.data}
-                processedData={chart.processedData}
-                xKey={chart.xKey}
-                yKey={chart.yKey}
-                series={chart.series}
-                colors={chart.colors}
-              />
-            ))}
+            {safeCharts.map((chart, index) => {
+              const chartKey =
+                "id" in chart && chart.id ? chart.id : `${chart.title ?? "chart"}-${index}`;
+
+              return (
+                <Chart
+                  key={chartKey}
+                  type={chart.type}
+                  title={chart.title}
+                  subtitle={chart.subtitle}
+                  data={chart.data}
+                  processedData={"processedData" in chart ? chart.processedData : undefined}
+                  xKey={chart.xKey}
+                  yKey={chart.yKey}
+                  series={chart.series}
+                  colors={chart.colors}
+                />
+              );
+            })}
           </section>
         )}
       </article>

--- a/web/components/charts/BaseChart.tsx
+++ b/web/components/charts/BaseChart.tsx
@@ -1,16 +1,30 @@
 "use client";
 
-import type { ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import { ResponsiveContainer } from 'recharts';
 
 interface BaseChartProps {
   title: string;
   subtitle?: string;
-  children: ReactNode;
+  children: ReactElement | null;
   className?: string;
 }
 
 export function BaseChart({ title, subtitle, children, className = '' }: BaseChartProps) {
+  if (!children) {
+    return (
+      <div className={`my-8 rounded-lg border border-slate-700 bg-slate-800/50 p-6 ${className}`}>
+        <div className="mb-4">
+          <h3 className="text-xl font-semibold text-white">{title}</h3>
+          {subtitle ? <p className="mt-1 text-sm text-slate-400">{subtitle}</p> : null}
+        </div>
+        <div className="flex h-80 items-center justify-center text-sm text-slate-400">
+          Chart configuration unavailable
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={`my-8 rounded-lg border border-slate-700 bg-slate-800/50 p-6 ${className}`}>
       <div className="mb-4">

--- a/web/lib/markdown.ts
+++ b/web/lib/markdown.ts
@@ -5,9 +5,10 @@ import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import rehypeStringify from "rehype-stringify";
 
-const DOMPurify = createDOMPurify(
-  typeof window === "undefined" ? undefined : (window as unknown as Window)
-);
+const windowLike =
+  typeof window === "undefined" ? undefined : (window as unknown as typeof globalThis);
+
+const DOMPurify = createDOMPurify(windowLike);
 
 export async function mdToHtml(md: string): Promise<string> {
   const source = typeof md === "string" ? md : "";

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -2,6 +2,7 @@ export type {
   Article,
   BaseArticle,
   ChartData,
+  ProcessedChartData,
   ChartSeries,
   ChartType,
   DashboardUser,

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "security-check": "npm audit --audit-level=high"
   },
   "dependencies": {
+    "@h4c/shared": "file:../shared",
     "next": "14.2.16",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/web/types/lru-cache.d.ts
+++ b/web/types/lru-cache.d.ts
@@ -1,0 +1,19 @@
+declare module 'lru-cache' {
+  interface LRUCacheOptions<K, V> {
+    max?: number;
+    ttl?: number;
+    allowStale?: boolean;
+  }
+
+  interface SetOptions {
+    ttl?: number;
+  }
+
+  export class LRUCache<K = any, V = any> {
+    constructor(options?: LRUCacheOptions<K, V>);
+    get(key: K): V | undefined;
+    set(key: K, value: V, options?: SetOptions): void;
+    delete(key: K): void;
+    keys(): IterableIterator<K>;
+  }
+}


### PR DESCRIPTION
## Summary
- share Render build helpers that expand npm timeouts and provide a consistent logging surface for both services
- harden the web build script to verify TypeScript dependencies, seed sample content, and reinstall only the needed workspace packages
- introduce a dedicated Render worker build script and point the bot service at it while wiring web and bot packages to the local shared workspace

## Testing
- bash scripts/render-build.sh *(fails: npm registry forbids downloading @commitlint/cli in the execution environment)*
- bash scripts/render-worker-build.sh *(fails: npm registry forbids downloading @commitlint/cli in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce583880688330b64dbe7911d19061