### PR TITLE
Harden lint and test tooling across monorepo

### DIFF
--- a/bot/package.json
+++ b/bot/package.json
@@ -6,8 +6,8 @@
     "dev": "node --watch src/index.js",
     "start": "node --no-warnings src/index.js",
     "build": "echo \"No build step needed for bot\"",
-    "lint": "eslint src/ --ext .js",
-    "lint:fix": "eslint src/ --ext .js --fix",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix",
     "type-check": "echo \"Bot is JavaScript - no type checking needed\"",
     "test": "node --test test/*.test.js",
     "test:watch": "node --test --watch test/*.test.js"

--- a/bot/src/index.js
+++ b/bot/src/index.js
@@ -572,23 +572,6 @@ client.on('guildMemberAdd', async (member) => {
   }
 });
 
-// ----------- Core community + personality handler -----------
-    logger.error({ error: String(error), member: member.id }, 'Failed to ensure user on join');
-  }
-
-  const channelId = Settings.welcomeChannelId;
-  if (!channelId) return;
-
-  const channel = await CommunityEngagementService.resolveChannel(channelId);
-  if (!channel) return;
-
-  try {
-    await channel.send(PersonalityService.welcomeMessage(member));
-  } catch (error) {
-    logger.error({ error: String(error), member: member.id }, 'Failed to send welcome message');
-  }
-});
-
 // ----------- GM auto-reply handler -----------
 client.on('messageCreate', async (message) => {
   if (

--- a/bot/src/slash/loader.js
+++ b/bot/src/slash/loader.js
@@ -1,50 +1,48 @@
 import { REST, Routes, SlashCommandBuilder } from 'discord.js';
+
 import { Env } from '../utils/envGuard.js';
 import { profileHandler } from './suites/profile.js';
 import { rolesyncHandler } from './suites/rolesync.js';
 import { emailHandler, emailRemoveHandler, emailStatusHandler } from './suites/email.js';
-import { randomFrom, quickQuips, chaosEvents, loreDrops, storyJabs, gmResponses, cryptoJokes, techFacts, memeVault } from '../utils/botResponses.js';
+import {
+  randomFrom,
+  quickQuips,
+  chaosEvents,
+  loreDrops,
+  storyJabs,
+  gmResponses,
+  cryptoJokes,
+  techFacts,
+  memeVault,
+} from '../utils/botResponses.js';
 import { PersonalityService } from '../services/personalityService.js';
 import { CommunityEngagementService } from '../services/communityEngagementService.js';
 import { logger } from '../utils/logger.js';
-
-function wrapReply(interaction, response, context = {}) {
-  const payload = PersonalityService.wrap(response, { user: interaction.user, ...context });
-  if (typeof payload === 'string') {
-    return interaction.reply({ content: payload, ephemeral: context.ephemeral });
-  }
-  return interaction.reply({ ...payload, ephemeral: context.ephemeral });
-}
-
 import { createWrapReply } from './wrapReply.js';
-import { logger } from '../utils/logger.js';
 
-const wrapReply = createWrapReply((response, ctx) => PersonalityService.wrap(response, ctx));
-
+const wrapReply = createWrapReply((response, context = {}) => PersonalityService.wrap(response, context));
 
 function buildDefinitions(client) {
   return [
     {
       name: 'gm',
-      builder: new SlashCommandBuilder()
-        .setName('gm')
-        .setDescription('Log a sarcastic GM and keep your streak alive.'),
+      builder: new SlashCommandBuilder().setName('gm').setDescription('Log a sarcastic GM and keep your streak alive.'),
       execute: async (interaction) => {
         const mockMessage = { author: interaction.user, channelId: interaction.channelId };
         const result = await CommunityEngagementService.handleGreeting(mockMessage, 'gm');
-        let content = randomFrom(gmResponses);
+        let content = randomFrom(gmResponses) ?? 'gm';
+
         if (result?.achievements?.length) {
-          const unlocked = result.achievements.map(a => `**${a.label}**`).join(', ');
+          const unlocked = result.achievements.map((a) => `**${a.label}**`).join(', ');
           content += `\nAchievement unlocked: ${unlocked}`;
         }
+
         await wrapReply(interaction, content);
-      }
+      },
     },
     {
       name: 'gn',
-      builder: new SlashCommandBuilder()
-        .setName('gn')
-        .setDescription('Clock out with style and track your GN streak.'),
+      builder: new SlashCommandBuilder().setName('gn').setDescription('Clock out with style and track your GN streak.'),
       execute: async (interaction) => {
         const mockMessage = { author: interaction.user, channelId: interaction.channelId };
         const result = await CommunityEngagementService.handleGreeting(mockMessage, 'gn');
@@ -52,59 +50,64 @@ function buildDefinitions(client) {
           'Sleep protocol engaged. Try not to dream about chart lines.',
           'Logging you off. May your bags inflate overnight.',
           'Night, legend. Your streak is safe—for now.',
-          'Power nap authorized. Return with alpha.'
+          'Power nap authorized. Return with alpha.',
         ];
-        let content = randomFrom(responses);
+        let content = randomFrom(responses) ?? 'gn';
+
         if (result?.achievements?.length) {
-          const unlocked = result.achievements.map(a => `**${a.label}**`).join(', ');
+          const unlocked = result.achievements.map((a) => `**${a.label}**`).join(', ');
           content += `\nNight shift unlocked: ${unlocked}`;
         }
+
         await wrapReply(interaction, content);
-      }
+      },
     },
     {
       name: 'joke',
       builder: new SlashCommandBuilder().setName('joke').setDescription('Request a crypto joke or fact.'),
       execute: async (interaction) => {
         const pool = [...cryptoJokes, ...techFacts];
-        await wrapReply(interaction, randomFrom(pool));
-      }
+        await wrapReply(interaction, randomFrom(pool) ?? 'All circuits empty. Try again.');
+      },
     },
     {
       name: 'quip',
       builder: new SlashCommandBuilder().setName('quip').setDescription('Grab a random quip or jab.'),
       execute: async (interaction) => {
         const categories = [quickQuips, chaosEvents, loreDrops, storyJabs];
-        await wrapReply(interaction, randomFrom(randomFrom(categories)));
-      }
+        const bucket = randomFrom(categories) ?? [];
+        await wrapReply(interaction, randomFrom(bucket) ?? 'The snark generator is cooling down.');
+      },
     },
     {
       name: 'jab',
       builder: new SlashCommandBuilder().setName('jab').setDescription('Ask the bot to roast you just a little.'),
-      execute: async (interaction) => wrapReply(interaction, randomFrom(storyJabs))
+      execute: async (interaction) => wrapReply(interaction, randomFrom(storyJabs) ?? 'Consider yourself gently roasted.'),
     },
     {
       name: 'lore',
       builder: new SlashCommandBuilder().setName('lore').setDescription('Drop a lore snippet straight from HQ.'),
-      execute: async (interaction) => wrapReply(interaction, randomFrom(loreDrops))
+      execute: async (interaction) => wrapReply(interaction, randomFrom(loreDrops) ?? 'Lore uplink unstable. Try again.'),
     },
     {
       name: 'chaos',
       builder: new SlashCommandBuilder().setName('chaos').setDescription('Summon a random chaos event.'),
-      execute: async (interaction) => wrapReply(interaction, randomFrom(chaosEvents))
+      execute: async (interaction) => wrapReply(interaction, randomFrom(chaosEvents) ?? 'Chaos temporarily contained.'),
     },
     {
       name: 'meme',
       builder: new SlashCommandBuilder().setName('meme').setDescription('Drop a meme from the vault.'),
       execute: async (interaction) => {
         const memeUrl = randomFrom(memeVault);
-        const { unlocks } = await CommunityEngagementService.incrementMeme(interaction.user.id);
-        let content = `Deploying meme artillery: ${memeUrl}`;
+        const { unlocks = [] } = await CommunityEngagementService.incrementMeme(interaction.user.id);
+        let content = memeUrl ? `Deploying meme artillery: ${memeUrl}` : 'Meme vault empty. Insert alpha.';
+
         if (unlocks.length) {
-          content += `\nAlso unlocked: ${unlocks.map(a => `**${a.label}**`).join(', ')}`;
+          content += `\nAlso unlocked: ${unlocks.map((a) => `**${a.label}**`).join(', ')}`;
         }
+
         await wrapReply(interaction, content, { noSuffix: true });
-      }
+      },
     },
     {
       name: 'achievements',
@@ -112,15 +115,19 @@ function buildDefinitions(client) {
       execute: async (interaction) => {
         await interaction.deferReply({ ephemeral: true });
         const achievements = await CommunityEngagementService.listAchievements(interaction.user.id);
+
         if (!achievements.length) {
           return interaction.editReply('No achievements yet—but the grind starts now.');
         }
 
         const lines = achievements
           .slice(0, 15)
-          .map(a => `• **${a.label}** — ${a.description} *(unlocked ${new Date(a.unlockedAt).toLocaleDateString()})*`);
-        return interaction.editReply(PersonalityService.wrap(`Flex report incoming:\n${lines.join('\n')}`, { disableSarcasm: true }));
-      }
+          .map((a) => `• **${a.label}** — ${a.description} *(unlocked ${new Date(a.unlockedAt).toLocaleDateString()})*`);
+
+        return interaction.editReply(
+          PersonalityService.wrap(`Flex report incoming:\n${lines.join('\n')}`, { disableSarcasm: true }),
+        );
+      },
     },
     {
       name: 'gmrank',
@@ -131,64 +138,44 @@ function buildDefinitions(client) {
           return wrapReply(interaction, 'No GM data yet. Someone start the streak.', { noSuffix: true });
         }
 
-        const lines = leaderboard.map((entry, index) => `${index + 1}. <@${entry.discordId}> — ${entry.community?.gmCount || 0} GM / ${entry.community?.gnCount || 0} GN`);
+        const lines = leaderboard.map(
+          (entry, index) => `${index + 1}. <@${entry.discordId}> — ${entry.community?.gmCount || 0} GM / ${entry.community?.gnCount || 0} GN`,
+        );
+
         await wrapReply(interaction, `GM Leaderboard:\n${lines.join('\n')}`, { noSuffix: true });
-      }
+      },
     },
     {
       name: 'profile',
       builder: new SlashCommandBuilder().setName('profile').setDescription('Show your H4C profile & reputation.'),
-      execute: profileHandler
+      execute: profileHandler,
     },
     {
       name: 'rolesync',
       builder: new SlashCommandBuilder().setName('rolesync').setDescription('Sync your roles from badges & HODL.'),
-      execute: (interaction) => rolesyncHandler(interaction, client)
+      execute: (interaction) => rolesyncHandler(interaction, client),
     },
     {
       name: 'email',
       builder: new SlashCommandBuilder()
         .setName('email')
         .setDescription('Manage your email subscription')
-        .addSubcommand(subcommand =>
+        .addSubcommand((subcommand) =>
           subcommand
             .setName('set')
             .setDescription('Set your email for $MemO updates')
-            .addStringOption(option =>
-              option
-                .setName('email')
-                .setDescription('Your email address')
-                .setRequired(true)
-            )
+            .addStringOption((option) => option.setName('email').setDescription('Your email address').setRequired(true)),
         )
-        .addSubcommand(subcommand =>
-          subcommand
-            .setName('remove')
-            .setDescription('Remove your email and unsubscribe')
-        )
-        .addSubcommand(subcommand =>
-          subcommand
-        )
-        .addSubcommand(subcommand =>
-          subcommand
-        )
-        .addSubcommand(subcommand =>
-          subcommand
-            .setName('remove')
-            .setDescription('Remove your email and unsubscribe')
-        )
-        .addSubcommand(subcommand =>
-          subcommand
-            .setName('status')
-            .setDescription('Check your email subscription status')
-        ),
+        .addSubcommand((subcommand) => subcommand.setName('remove').setDescription('Remove your email and unsubscribe'))
+        .addSubcommand((subcommand) => subcommand.setName('status').setDescription('Check your email subscription status')),
       execute: async (interaction) => {
         const subcommand = interaction.options.getSubcommand();
         if (subcommand === 'set') return emailHandler(interaction);
         if (subcommand === 'remove') return emailRemoveHandler(interaction);
         if (subcommand === 'status') return emailStatusHandler(interaction);
-      }
-    }
+        return interaction.reply({ content: 'Unsupported email action.', ephemeral: true });
+      },
+    },
   ];
 }
 
@@ -196,29 +183,14 @@ export async function loadSlashCommands(client) {
   const rest = new REST({ version: '10' }).setToken(Env.BOT_TOKEN);
   const definitions = buildDefinitions(client);
 
-  await rest.put(
-    Routes.applicationGuildCommands(client.user.id, Env.DISCORD_GUILD_ID),
-    { body: definitions.map(def => def.builder.toJSON()) }
-  );
+  await rest.put(Routes.applicationGuildCommands(client.user.id, Env.DISCORD_GUILD_ID), {
+    body: definitions.map((def) => def.builder.toJSON()),
+  });
 
   if (!client.slashCommands || typeof client.slashCommands.set !== 'function') {
     client.slashCommands = new Map();
   } else if (typeof client.slashCommands.clear === 'function') {
     client.slashCommands.clear();
-  }
-
-  for (const def of definitions) {
-    client.slashCommands.set(def.name, def);
-  }
-
-  if (!client.slashCommands || typeof client.slashCommands.set !== 'function') {
-    client.slashCommands = new Map();
-  } else if (typeof client.slashCommands.clear === 'function') {
-    client.slashCommands.clear();
-  }
-
-  for (const def of definitions) {
-    client.slashCommands.set(def.name, def);
   }
 
   for (const def of definitions) {
@@ -231,10 +203,13 @@ export async function loadSlashCommands(client) {
 
       const command = client.slashCommands.get(interaction.commandName);
       if (!command) {
-        logger.warn({
-          command: interaction.commandName,
-          user: interaction.user.tag
-        }, 'Unknown slash command attempted (fallback handler)');
+        logger.warn(
+          {
+            command: interaction.commandName,
+            user: interaction.user.tag,
+          },
+          'Unknown slash command attempted',
+        );
         return;
       }
 
@@ -243,69 +218,31 @@ export async function loadSlashCommands(client) {
       try {
         await command.execute(interaction);
         const duration = Date.now() - startTime;
-
-        logger.info({
-          command: interaction.commandName,
-          user: interaction.user.tag,
-          guild: interaction.guild?.name,
-          duration
-        }, 'Slash command executed successfully (fallback handler)');
+        logger.info(
+          {
+            command: interaction.commandName,
+            user: interaction.user.tag,
+            guild: interaction.guild?.name,
+            duration,
+          },
+          'Slash command executed successfully',
+        );
       } catch (error) {
         const duration = Date.now() - startTime;
-
-        logger.error({
-          error,
-          command: interaction.commandName,
-          user: interaction.user.tag,
-          duration
-        }, 'Slash command execution failed (fallback handler)');
-
-        logger.info({
-          command: interaction.commandName,
-          user: interaction.user.tag,
-          guild: interaction.guild?.name,
-          duration
-        }, 'Slash command executed successfully (fallback handler)');
-      } catch (error) {
-        const duration = Date.now() - startTime;
-
-        logger.error({
-          error,
-          command: interaction.commandName,
-          user: interaction.user.tag,
-          duration
-        }, 'Slash command execution failed (fallback handler)');
-
-      try {
-        await command.execute(interaction);
-        const duration = Date.now() - startTime;
-
-        logger.info({
-          command: interaction.commandName,
-          user: interaction.user.tag,
-          guild: interaction.guild?.name,
-          duration
-        }, 'Slash command executed successfully (fallback handler)');
-      } catch (error) {
-        const duration = Date.now() - startTime;
-
-        logger.error({
-          error,
-          command: interaction.commandName,
-          user: interaction.user.tag,
-          duration
-        }, 'Slash command execution failed (fallback handler)');
-
-        logger.error({
-          error,
-          command: interaction.commandName,
-          user: interaction.user.tag,
-          duration
-        }, 'Slash command execution failed (fallback handler)');
+        logger.error(
+          {
+            error,
+            command: interaction.commandName,
+            user: interaction.user.tag,
+            guild: interaction.guild?.name,
+            duration,
+          },
+          'Slash command execution failed',
+        );
 
         const reply = {
           content: 'There was an error executing this command. Please try again later.',
-          ephemeral: true
+          ephemeral: true,
         };
 
         try {
@@ -315,189 +252,12 @@ export async function loadSlashCommands(client) {
             await interaction.reply(reply);
           }
         } catch (replyError) {
-          logger.error(replyError, 'Failed to send slash command error response (fallback handler)');
-
-function buildDefinitions(client) {
-  return [
-    {
-      name: 'gm',
-      builder: new SlashCommandBuilder()
-        .setName('gm')
-        .setDescription('Log a sarcastic GM and keep your streak alive.'),
-      execute: async (interaction) => {
-        const mockMessage = { author: interaction.user, channelId: interaction.channelId };
-        const result = await CommunityEngagementService.handleGreeting(mockMessage, 'gm');
-        let content = randomFrom(gmResponses);
-        if (result?.achievements?.length) {
-          const unlocked = result.achievements.map(a => `**${a.label}**`).join(', ');
-          content += `\nAchievement unlocked: ${unlocked}`;
+          logger.error(replyError, 'Failed to send slash command error response');
         }
-        await wrapReply(interaction, content);
       }
     });
 
     client.__h4cSlashHandlerBound = true;
-  }
-
-    },
-    {
-      name: 'gn',
-      builder: new SlashCommandBuilder()
-        .setName('gn')
-        .setDescription('Clock out with style and track your GN streak.'),
-      execute: async (interaction) => {
-        const mockMessage = { author: interaction.user, channelId: interaction.channelId };
-        const result = await CommunityEngagementService.handleGreeting(mockMessage, 'gn');
-        const responses = [
-          'Sleep protocol engaged. Try not to dream about chart lines.',
-          'Logging you off. May your bags inflate overnight.',
-          'Night, legend. Your streak is safe—for now.',
-          'Power nap authorized. Return with alpha.'
-        ];
-        let content = randomFrom(responses);
-        if (result?.achievements?.length) {
-          const unlocked = result.achievements.map(a => `**${a.label}**`).join(', ');
-          content += `\nNight shift unlocked: ${unlocked}`;
-        }
-        await wrapReply(interaction, content);
-      }
-    },
-    {
-      name: 'joke',
-      builder: new SlashCommandBuilder().setName('joke').setDescription('Request a crypto joke or fact.'),
-      execute: async (interaction) => {
-        const pool = [...cryptoJokes, ...techFacts];
-        await wrapReply(interaction, randomFrom(pool));
-      }
-    },
-    {
-      name: 'quip',
-      builder: new SlashCommandBuilder().setName('quip').setDescription('Grab a random quip or jab.'),
-      execute: async (interaction) => {
-        const categories = [quickQuips, chaosEvents, loreDrops, storyJabs];
-        await wrapReply(interaction, randomFrom(randomFrom(categories)));
-      }
-    },
-    {
-      name: 'jab',
-      builder: new SlashCommandBuilder().setName('jab').setDescription('Ask the bot to roast you just a little.'),
-      execute: async (interaction) => wrapReply(interaction, randomFrom(storyJabs))
-    },
-    {
-      name: 'lore',
-      builder: new SlashCommandBuilder().setName('lore').setDescription('Drop a lore snippet straight from HQ.'),
-      execute: async (interaction) => wrapReply(interaction, randomFrom(loreDrops))
-    },
-    {
-      name: 'chaos',
-      builder: new SlashCommandBuilder().setName('chaos').setDescription('Summon a random chaos event.'),
-      execute: async (interaction) => wrapReply(interaction, randomFrom(chaosEvents))
-    },
-    {
-      name: 'meme',
-      builder: new SlashCommandBuilder().setName('meme').setDescription('Drop a meme from the vault.'),
-      execute: async (interaction) => {
-        const memeUrl = randomFrom(memeVault);
-        const { unlocks } = await CommunityEngagementService.incrementMeme(interaction.user.id);
-        let content = `Deploying meme artillery: ${memeUrl}`;
-        if (unlocks.length) {
-          content += `\nAlso unlocked: ${unlocks.map(a => `**${a.label}**`).join(', ')}`;
-        }
-        await wrapReply(interaction, content, { noSuffix: true });
-      }
-    });
-
-    client.__h4cSlashHandlerBound = true;
-  }
-
-    },
-    {
-      name: 'achievements',
-      builder: new SlashCommandBuilder().setName('achievements').setDescription('Review your unlocked achievements.'),
-      execute: async (interaction) => {
-        await interaction.deferReply({ ephemeral: true });
-        const achievements = await CommunityEngagementService.listAchievements(interaction.user.id);
-        if (!achievements.length) {
-          return interaction.editReply('No achievements yet—but the grind starts now.');
-        }
-
-        const lines = achievements
-          .slice(0, 15)
-          .map(a => `• **${a.label}** — ${a.description} *(unlocked ${new Date(a.unlockedAt).toLocaleDateString()})*`);
-        return interaction.editReply(PersonalityService.wrap(`Flex report incoming:\n${lines.join('\n')}`, { disableSarcasm: true }));
-      }
-    },
-    {
-      name: 'gmrank',
-      builder: new SlashCommandBuilder().setName('gmrank').setDescription('See the GM/GN leaderboard.'),
-      execute: async (interaction) => {
-        const leaderboard = await CommunityEngagementService.getLeaderboard('gm', 10);
-        if (!leaderboard.length) {
-          return wrapReply(interaction, 'No GM data yet. Someone start the streak.', { noSuffix: true });
-        }
-
-        const lines = leaderboard.map((entry, index) => `${index + 1}. <@${entry.discordId}> — ${entry.community?.gmCount || 0} GM / ${entry.community?.gnCount || 0} GN`);
-        await wrapReply(interaction, `GM Leaderboard:\n${lines.join('\n')}`, { noSuffix: true });
-      }
-    },
-    {
-      name: 'profile',
-      builder: new SlashCommandBuilder().setName('profile').setDescription('Show your H4C profile & reputation.'),
-      execute: profileHandler
-    },
-    {
-      name: 'rolesync',
-      builder: new SlashCommandBuilder().setName('rolesync').setDescription('Sync your roles from badges & HODL.'),
-      execute: (interaction) => rolesyncHandler(interaction, client)
-    },
-    {
-      name: 'email',
-      builder: new SlashCommandBuilder()
-        .setName('email')
-        .setDescription('Manage your email subscription')
-        .addSubcommand(subcommand =>
-          subcommand
-            .setName('set')
-            .setDescription('Set your email for $MemO updates')
-            .addStringOption(option =>
-              option
-                .setName('email')
-                .setDescription('Your email address')
-                .setRequired(true)
-            )
-        )
-        .addSubcommand(subcommand =>
-          subcommand
-            .setName('remove')
-            .setDescription('Remove your email and unsubscribe')
-        )
-        .addSubcommand(subcommand =>
-          subcommand
-            .setName('status')
-            .setDescription('Check your email subscription status')
-        ),
-      execute: async (interaction) => {
-        const subcommand = interaction.options.getSubcommand();
-        if (subcommand === 'set') return emailHandler(interaction);
-        if (subcommand === 'remove') return emailRemoveHandler(interaction);
-        if (subcommand === 'status') return emailStatusHandler(interaction);
-      }
-    }
-  ];
-}
-
-export async function loadSlashCommands(client) {
-  const rest = new REST({ version: '10' }).setToken(Env.BOT_TOKEN);
-  const definitions = buildDefinitions(client);
-
-  await rest.put(
-    Routes.applicationGuildCommands(client.user.id, Env.DISCORD_GUILD_ID),
-    { body: definitions.map(def => def.builder.toJSON()) }
-  );
-
-  client.slashCommands.clear();
-  for (const def of definitions) {
-    client.slashCommands.set(def.name, def);
   }
 
   logger.info({ count: definitions.length }, 'Slash commands registered');

--- a/bot/src/utils/botResponses.js
+++ b/bot/src/utils/botResponses.js
@@ -2,52 +2,23 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-const responsesDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../bot responses/');
-
-function loadJson(file, key) {
-  const filePath = path.join(responsesDir, file);
-  const payload = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-  if (key && payload[key]) return payload[key];
-  if (key && payload[key.toLowerCase()]) return payload[key.toLowerCase()];
-  const firstKey = Object.keys(payload)[0];
-  return firstKey ? payload[firstKey] : [];
-}
-
-const responsesDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../bot responses/');
-
-function loadJson(file, key) {
-  const filePath = path.join(responsesDir, file);
-  const payload = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-  if (key && payload[key]) return payload[key];
-  if (key && payload[key.toLowerCase()]) return payload[key.toLowerCase()];
-  const firstKey = Object.keys(payload)[0];
-  return firstKey ? payload[firstKey] : [];
-}
-
-}
-
-// Fix for ES modules - get current directory
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-// Correct path to bot responses directory
-const responsesDir = path.resolve(__dirname, '../bot responses/');
+const responsesDir = path.resolve(__dirname, '../bot responses');
 
 function loadJson(file, key) {
   try {
     const filePath = path.join(responsesDir, file);
-    
-    // Check if file exists first
     if (!fs.existsSync(filePath)) {
       console.warn(`Bot response file not found: ${filePath}`);
       return [];
     }
-    
+
     const payload = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-    
+
     if (key && payload[key]) return payload[key];
     if (key && payload[key.toLowerCase()]) return payload[key.toLowerCase()];
-    
+
     const firstKey = Object.keys(payload)[0];
     return firstKey ? payload[firstKey] : [];
   } catch (error) {
@@ -56,7 +27,6 @@ function loadJson(file, key) {
   }
 }
 
-// Load all responses with fallbacks
 export const chaosEvents = loadJson('chaos_events.json', 'ChaosEvents');
 export const loreDrops = loadJson('lore_drops.json', 'LoreDrops');
 export const quickQuips = loadJson('quick_quips.json', 'QuickQuips');
@@ -65,24 +35,10 @@ export const gmResponses = loadJson('gmResponses.json', 'GMResponses');
 export const cryptoJokes = loadJson('cryptoJokes.json', 'CryptoJokes');
 export const techFacts = loadJson('techCryptoFacts.json', 'TechCryptoFacts');
 export const memeVault = loadJson('memes.json', 'Memes');
-export function randomFrom(arr) {
-  if (!Array.isArray(arr) || arr.length === 0) return undefined;
-export function randomFrom(arr) {
-  if (!Array.isArray(arr) || arr.length === 0) return undefined;
-
-export function randomFrom(arr) {
-  if (!Array.isArray(arr) || arr.length === 0) return undefined;
-
-export const gmResponses = loadJson('gmResponses.json', 'gmResponses');
-export const cryptoJokes = loadJson('cryptoJokes.json', 'cryptoJokes');
-export const techFacts = loadJson('techCryptoFacts.json', 'techCryptoFacts');
-export const memeVault = loadJson('memes.json', 'Memes');
 
 export function randomFrom(arr) {
   if (!Array.isArray(arr) || arr.length === 0) {
-    console.warn('randomFrom called with empty or invalid array');
-    return 'Default response';
+    return undefined;
   }
-  
   return arr[Math.floor(Math.random() * arr.length)];
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13579,7 +13579,9 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "eslint": "^8.57.0"
+        "eslint": "^8.57.0",
+        "@eslint/js": "^8.57.1",
+        "globals": "^13.24.0"
       },
       "peerDependencies": {
         "node": ">=18.18.0"

--- a/shared/CacheManager.js
+++ b/shared/CacheManager.js
@@ -1,7 +1,5 @@
 import { redis } from './database/redis.js';
 import { logger } from './utils/logger.js';
-import { config } from './config/index.js';
-
 export class CacheManager {
   constructor() {
     this.memoryCache = new Map();

--- a/shared/errors/ErrorHandler.js
+++ b/shared/errors/ErrorHandler.js
@@ -63,7 +63,7 @@ export class ErrorHandler {
   }
   
   static createMiddleware() {
-    return (error, req, res, next) => {
+    return (error, req, res, _next) => {
       const context = {
         operation: `${req.method} ${req.path}`,
         requestId: req.id,

--- a/shared/eslint.config.js
+++ b/shared/eslint.config.js
@@ -1,0 +1,36 @@
+import js from "@eslint/js";
+import globals from "globals";
+
+const baseConfig = js.configs.recommended;
+
+export default [
+  {
+    ignores: [
+      "node_modules/",
+      "dist/",
+      "coverage/",
+      "*.config.js",
+      "test/fixtures/",
+    ],
+  },
+  {
+    files: ["**/*.js"],
+    languageOptions: {
+      ...baseConfig.languageOptions,
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      ...baseConfig.rules,
+      "no-console": "off",
+      "no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "prefer-const": ["error", { destructuring: "all" }],
+      "eqeqeq": ["error", "smart"],
+      "no-var": "error",
+      "object-shorthand": "error",
+    },
+  },
+];

--- a/shared/package.json
+++ b/shared/package.json
@@ -28,8 +28,8 @@
     "build": "echo \"Shared package build complete\"",
     "test": "node --test test/*.test.js || echo \"No shared tests found\"",
     "test:watch": "node --test --watch test/*.test.js",
-    "lint": "eslint . --ext .js",
-    "lint:fix": "eslint . --ext .js --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "type-check": "echo \"Shared is JavaScript - no type checking needed\""
   },
   "dependencies": {
@@ -41,7 +41,9 @@
     "pino-pretty": "^11.2.2"
   },
   "devDependencies": {
-    "eslint": "^8.57.0"
+    "eslint": "^8.57.0",
+    "@eslint/js": "^8.57.1",
+    "globals": "^13.24.0"
   },
   "peerDependencies": {
     "node": ">=18.18.0"

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -9,6 +9,7 @@ const customJestConfig = {
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/$1",
+    "@testing-library/user-event": "<rootDir>/test-utils/user-event.ts",
   },
   testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/"],
 };

--- a/web/jest.setup.ts
+++ b/web/jest.setup.ts
@@ -1,1 +1,9 @@
-export {};
+import "@testing-library/jest-dom";
+
+if (!globalThis.fetch) {
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    writable: true,
+    value: jest.fn(() => Promise.reject(new Error("fetch not implemented in tests"))) as typeof fetch,
+  });
+}

--- a/web/lib/content.ts
+++ b/web/lib/content.ts
@@ -18,6 +18,7 @@ function resolveContentDirectory(): string {
   for (const candidate of candidates) {
     try {
       if (fs.existsSync(candidate)) {
+        console.log(`✓ Content found at: ${candidate}`);
         return candidate;
       }
     } catch (error) {
@@ -25,48 +26,18 @@ function resolveContentDirectory(): string {
     }
   }
 
-  const fallback = candidates[0] ?? path.resolve(process.cwd(), "..", "content", "mega_article");
-  console.warn(`Content directory not found. Falling back to ${fallback}`);
+  const fallback = candidates[0] ?? path.resolve(process.cwd(), "content", "mega_article");
+  console.warn(`⚠️ Content directory not found. Falling back to ${fallback}`);
   return fallback;
 }
 
-// Content lives in content/mega_article/*.json, but allow overrides for hosted builds
 const CONTENT_DIR = resolveContentDirectory();
-
-// FIXED: Content directory resolution for Render deployment
-const CONTENT_DIR = (() => {
-  // In production/build, content is at web/content/mega_article
-  const primaryPath = path.join(process.cwd(), "content", "mega_article");
-  const webPath = path.join(process.cwd(), "web", "content", "mega_article");
-  
-  // Check both possible locations
-  if (fs.existsSync(primaryPath)) {
-    console.log(`✓ Content found at: ${primaryPath}`);
-    return primaryPath;
-  }
-  
-  if (fs.existsSync(webPath)) {
-    console.log(`✓ Content found at: ${webPath}`);
-    return webPath;
-  }
-  
-  // For Render, during build the structure might be different
-  // Try relative to where Next.js runs from
-  const buildPath = path.resolve("content", "mega_article");
-  if (fs.existsSync(buildPath)) {
-    console.log(`✓ Content found at: ${buildPath}`);
-    return buildPath;
-  }
-  
-  console.warn(`⚠️ Content directory not found, using: ${primaryPath}`);
-  return primaryPath;
-})();
 
 // Log what files we can see (helpful for debugging)
 console.log("Content directory status:", {
   exists: fs.existsSync(CONTENT_DIR),
   path: CONTENT_DIR,
-  files: fs.existsSync(CONTENT_DIR) ? fs.readdirSync(CONTENT_DIR).filter(f => f.endsWith('.json')) : []
+  files: fs.existsSync(CONTENT_DIR) ? fs.readdirSync(CONTENT_DIR).filter((f) => f.endsWith(".json")) : [],
 });
 
 // FIXED: Build-safe directory listing

--- a/web/test-utils/user-event.ts
+++ b/web/test-utils/user-event.ts
@@ -1,0 +1,55 @@
+import { fireEvent } from "@testing-library/react";
+
+type SetupOptions = {
+  advanceTimers?: (ms: number) => void;
+};
+
+type User = {
+  type: (element: HTMLElement, text: string) => Promise<void>;
+  click: (element: Element) => Promise<void>;
+};
+
+function updateValue(element: HTMLElement, value: string) {
+  const input = element as HTMLInputElement | HTMLTextAreaElement;
+  if ("value" in input) {
+    Object.defineProperty(input, "value", {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    });
+    fireEvent.input(input, { target: { value } });
+  } else {
+    fireEvent.input(element, { target: { value } });
+  }
+}
+
+export function setup(options: SetupOptions = {}): User {
+  const maybeAdvance = (ms: number) => {
+    try {
+      options.advanceTimers?.(ms);
+    } catch {
+      // ignore timer advance errors
+    }
+  };
+
+  return {
+    async type(element, text) {
+      const currentValue = (element as HTMLInputElement | HTMLTextAreaElement).value ?? "";
+      let nextValue = currentValue;
+      for (const char of text) {
+        nextValue += char;
+        updateValue(element, nextValue);
+        maybeAdvance(0);
+        await Promise.resolve();
+      }
+    },
+    async click(element) {
+      fireEvent.click(element);
+      maybeAdvance(0);
+      await Promise.resolve();
+    },
+  };
+}
+
+export default { setup };


### PR DESCRIPTION
## Summary
- add a flat ESLint config for the shared workspace and align lint scripts/dependencies with the new runner
- clean up shared validation utilities plus bot caching/command code so lint now passes without duplicates or dead imports
- rebuild the slash command loader, add a lightweight user-event test stub, and simplify content path detection so Jest can run offline

## Testing
- NEXT_IGNORE_INCORRECT_LOCKFILE=1 npm run test
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68d3588ea5148330a08eee242930f513