### PR TITLE
Refine Render deployment scripts

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,36 +6,6 @@ services:
     plan: starter  # Free tier
     buildCommand: ./scripts/render-build.sh
 
-    buildCommand: |
-      echo "=== H4C Web Build Starting ===" &&
-      echo "Node: $(node --version)" &&
-      echo "NPM: $(npm --version)" &&
-      echo "Working directory: $(pwd)" &&
-      echo "Directory structure:" &&
-      ls -la &&
-      echo "=== Creating content if missing ===" &&
-      if [ ! -d "web/content/mega_article" ]; then
-        mkdir -p web/content/mega_article &&
-        echo '{"slug":"foreword","title":"Welcome to H4C","sections":[{"heading":"Introduction","body":"Welcome to the H4C platform"}]}' > web/content/mega_article/foreword.json &&
-        echo '{"slug":"bitcoin","title":"Bitcoin Guide","sections":[{"heading":"Introduction","body":"Learn about Bitcoin"}]}' > web/content/mega_article/bitcoin.json &&
-        echo '{"slug":"ethereum","title":"Ethereum Guide","sections":[{"heading":"Introduction","body":"Learn about Ethereum"}]}' > web/content/mega_article/ethereum.json &&
-        echo '{"slug":"algorand","title":"Algorand Guide","sections":[{"heading":"Introduction","body":"Learn about Algorand"}]}' > web/content/mega_article/algorand.json &&
-        echo "Created sample content files"
-      fi &&
-      echo "=== Installing dependencies ===" &&
-      npm ci --production=false --loglevel=error &&
-      echo "=== Building web ===" &&
-      cd web &&
-      if [ ! -f "next-env.d.ts" ]; then
-        echo '/// <reference types="next" />' > next-env.d.ts &&
-        echo '/// <reference types="next/image-types/global" />' >> next-env.d.ts
-      fi &&
-      npm ci --production=false --loglevel=error &&
-      echo "Content check:" &&
-      ls -la content/mega_article/ 2>/dev/null || ls -la ../content/mega_article/ 2>/dev/null || echo "Using fallback content" &&
-      npm run build &&
-      echo "=== Build Complete ==="
-
     startCommand: cd web && npm start
     envVars:
       - key: NODE_ENV

--- a/scripts/render-common.sh
+++ b/scripts/render-common.sh
@@ -60,18 +60,13 @@ setup_npm_env() {
   export NPM_CONFIG_AUDIT=false
   export NPM_CONFIG_FUND=false
   export NPM_CONFIG_REGISTRY="${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org/}"
-  export NPM_CONFIG_FETCH_TIMEOUT="${NPM_CONFIG_FETCH_TIMEOUT:-300000}"
-  export NPM_CONFIG_FETCH_RETRIES="${NPM_CONFIG_FETCH_RETRIES:-10}"
-  export NPM_CONFIG_FETCH_RETRY_MINTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MINTIMEOUT:-60000}"
-  export NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT:-300000}"
-  export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm}"
-  export H4C_NPM_INSTALL_ATTEMPTS="${H4C_NPM_INSTALL_ATTEMPTS:-4}"
-  export H4C_NPM_INSTALL_DELAY="${H4C_NPM_INSTALL_DELAY:-10}"
   export NPM_CONFIG_FETCH_TIMEOUT="${NPM_CONFIG_FETCH_TIMEOUT:-120000}"
   export NPM_CONFIG_FETCH_RETRIES="${NPM_CONFIG_FETCH_RETRIES:-5}"
   export NPM_CONFIG_FETCH_RETRY_MINTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MINTIMEOUT:-20000}"
   export NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT="${NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT:-120000}"
   export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm}"
+  export H4C_NPM_INSTALL_ATTEMPTS="${H4C_NPM_INSTALL_ATTEMPTS:-4}"
+  export H4C_NPM_INSTALL_DELAY="${H4C_NPM_INSTALL_DELAY:-10}"
 }
 
 run_npm_install() {
@@ -92,10 +87,5 @@ run_npm_install() {
   else
     log "No lockfile found in $resolved_dir, running npm install"
     retry_command "$H4C_NPM_INSTALL_ATTEMPTS" "$H4C_NPM_INSTALL_DELAY" run_in_dir "$dir" npm install "${install_args[@]}"
-    (cd "$dir" && npm ci "${install_args[@]}")
-  else
-    log "No lockfile found in $resolved_dir, running npm install"
-    (cd "$dir" && npm install "${install_args[@]}")
   fi
 }
-

--- a/scripts/render-worker-build.sh
+++ b/scripts/render-worker-build.sh
@@ -9,34 +9,26 @@ trap 'log "Render bot build failed on line $LINENO"' ERR
 
 setup_npm_env
 
-log "H4C Bot Build Script Starting"
-log "Current directory: $(pwd)"
-log "Directory contents:"
+log "H4C Bot build starting"
+log "Working directory: $(pwd)"
 ls -la
 log "Node version: $(node --version)"
 log "npm version: $(npm --version)"
+
 log "Installing repository dependencies"
-run_npm_install "."
+run_npm_install "." --include=dev
 
 log "Building shared workspace"
 npm run build --workspace=@h4c/shared --if-present
-log "Installing bot workspace dependencies"
-if [ -f "package-lock.json" ] || [ -f "npm-shrinkwrap.json" ]; then
-  run_npm_install "." --omit=dev --workspace=@h4c/shared --workspace=@h4c/bot
-else
-  log "No root lockfile detected, falling back to direct workspace installs"
-  [ -d "shared" ] && run_npm_install "shared" --omit=dev
-  run_npm_install "bot" --omit=dev
-fi
 
 if [ -d "shared" ]; then
-  log "Installing shared workspace dependencies"
+  log "Ensuring shared workspace dependencies"
   run_npm_install "shared" --omit=dev
 else
-  log "Shared workspace not found, skipping install"
+  log "Shared workspace directory not found; skipping shared install"
 fi
 
-log "Installing bot workspace dependencies"
+log "Ensuring bot workspace dependencies"
 run_npm_install "bot" --omit=dev
 
 cd bot
@@ -56,10 +48,6 @@ if ! npm ls @h4c/shared --depth=0 >/dev/null 2>&1; then
   npm install --no-save --no-package-lock --no-audit --no-fund ../shared
 else
   log "@h4c/shared workspace dependency verified"
-  log "Linking @h4c/shared dependency for bot runtime"
-  npm install --no-save --no-package-lock --no-audit --no-fund ../shared
-else
-  log "@h4c/shared workspace dependency already linked"
 fi
 
 log "Bot workspace ready for Render"


### PR DESCRIPTION
## Summary
- clean up shared Render helper to provide consistent npm retries
- rewrite the web build script into a single linear flow that preserves sample content and workspace installs
- streamline the worker build script and remove the duplicate inline build command from render.yaml

## Testing
- bash -n scripts/render-common.sh
- bash -n scripts/render-build.sh
- bash -n scripts/render-worker-build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d3820f497c8330a3bed0d03a0f5883